### PR TITLE
docs: zero-to-hero README and docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,60 @@
 # HiveMind Integration for Home Assistant
 
-This is a **manual install** Home Assistant integration for connecting to an OpenVoiceOS instance via HiveMind
+A **manual-install** Home Assistant custom integration (`domain: hivemind`) that
+connects Home Assistant to an [OpenVoiceOS](https://openvoiceos.com) instance over
+the [HiveMind](https://github.com/JarbasHiveMind/HiveMind-core) protocol and
+exposes OVOS as Home Assistant entities.
 
-It allows Home Assistant to directly control and interact with an OVOS device at a system level — not just sending voice commands, but also manipulating services like audio playback, volume, and system power.
+It does more than send voice commands: it controls the OVOS device at a system
+level — audio playback, volume, microphone, sleep/wake, and system power — by
+injecting low-level bus messages over the HiveMind link.
+
+## Where it sits
+
+Home Assistant connects to a HiveMind hub
+([hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core)) running
+alongside an OVOS instance, using a HiveMind **client key**. Because the
+integration injects low-level bus messages rather than just utterances, that client
+must have **admin** privileges and the message-type allowlist described under
+[Permissions Required](#permissions-required).
+
+## Prerequisites
+
+- A running HiveMind hub (`hivemind-core`) reachable from Home Assistant.
+- An admin-privileged HiveMind client key + password registered on the hub for
+  Home Assistant (see [Permissions Required](#permissions-required)).
+- Home Assistant with access to its `config/custom_components/` directory.
+- The integration declares the runtime requirement `hivemind_bus_client>=0.4.3`
+  (pulled in by Home Assistant on first load).
+
+## Configuration fields
+
+When you add the integration (Settings → Devices & Services → Add Integration →
+HiveMind), the config flow asks for:
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `device_type` | `voice_assistant` | Which OVOS capabilities to expose (see below). |
+| `name` | — | Friendly name for the device in Home Assistant. |
+| `host` | — | HiveMind hub host (e.g. `ws://192.168.1.10`). |
+| `access_key` | — | HiveMind client access key. |
+| `password` | — | HiveMind client password. |
+| `port` | `5678` | HiveMind WebSocket port. |
+| `legacy_audio` | `false` | Use the legacy Audio Service instead of OCP. |
+| `site_id` | `unknown` | OVOS site id. |
+| `allow_self_signed` | `false` | Accept a self-signed TLS certificate. |
+
+### Device types
+
+The `device_type` controls which platforms are set up:
+
+| Type | Exposes |
+| --- | --- |
+| `agent` | binary sensors, buttons, switches (text I/O only). |
+| `media_player` | the above + `notify` + `media_player`. |
+| `voice_assistant` | the above + `select` + `sensor` (full mic/VAD/STT device). |
+
+See [`docs/`](docs/index.md) for the full setup, entity, and permissions walkthrough.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,34 @@
+# Configuration
+
+Configuration is done entirely through the Home Assistant config flow when adding
+the integration; there is no YAML.
+
+## Fields
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `device_type` | `voice_assistant` | Which OVOS capabilities to expose. |
+| `name` | — | Friendly name for the device in Home Assistant. |
+| `host` | — | HiveMind hub host (e.g. `ws://192.168.1.10`). |
+| `access_key` | — | HiveMind client access key. |
+| `password` | — | HiveMind client password. |
+| `port` | `5678` | HiveMind WebSocket port. |
+| `legacy_audio` | `false` | Use the legacy Audio Service instead of OCP for playback. |
+| `site_id` | `unknown` | OVOS site id. |
+| `allow_self_signed` | `false` | Accept a self-signed TLS certificate from the hub. |
+
+## Device types
+
+`device_type` selects which platforms are set up for the device:
+
+| Type | Description | Platforms |
+| --- | --- | --- |
+| `agent` | Text input/output only (e.g. an LLM-backed OVOS). | binary_sensor, button, switch |
+| `media_player` | Audio output (playback, volume, TTS). | the above + notify + media_player |
+| `voice_assistant` | Full device: agent + audio out + audio in (mic, VAD, wake word, STT). | the above + select + sensor |
+
+## Identity storage
+
+The integration writes its HiveMind node identity to `_identity.json` inside the
+installed `custom_components/hivemind/` package directory. The bus uses a fixed
+session id (`default`) so the hub does not assign a random session per connection.

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -1,0 +1,43 @@
+# Entities
+
+Which entities appear depends on the configured `device_type` (see
+[configuration](configuration.md)). The table notes the minimum device type that
+exposes each.
+
+## Always (all device types)
+
+| Entity | Platform | Purpose |
+| --- | --- | --- |
+| Connection | binary_sensor | Whether the HiveMind link is up. |
+| Alive / Ready | binary_sensor | OVOS service liveness/readiness. |
+| Speaking | binary_sensor | Whether OVOS is currently speaking. |
+| Reconnect | button | Re-establish the HiveMind connection. |
+| Reboot / Shutdown | button | System power control (via PHAL). |
+| Restart service | button | Restart the OVOS service. |
+| Mic listen | button | Trigger a listening cycle. |
+| Stop | button | `mycroft.stop`. |
+| SSH | switch | Toggle SSH (PHAL system plugin). |
+| Volume mute | switch | Mute/unmute output volume. |
+| Mic mute | switch | Mute/unmute the microphone. |
+| Sleep mode | switch | Put OVOS to sleep / wake it. |
+
+## `media_player` and `voice_assistant`
+
+| Entity | Platform | Purpose |
+| --- | --- | --- |
+| Media player | media_player | OCP-backed playback, volume, transport controls. |
+| Notify | notify | Send text to OVOS to speak (TTS). |
+
+The media player maps Home Assistant `MediaType` values to OVOS OCP media types
+(music, video, movie, episode, TV channel, game, …). With `legacy_audio` enabled it
+drives the legacy Audio Service instead of OCP.
+
+## `voice_assistant` only
+
+| Entity | Platform | Purpose |
+| --- | --- | --- |
+| Listener state | sensor | Current listener/recognizer state. |
+| Listening mode | select | Switch the listening mode. |
+
+These cover the microphone / VAD / STT side that only a full voice assistant device
+exposes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,26 @@
+# HiveMind for Home Assistant
+
+A manual-install Home Assistant integration that connects HA to an OpenVoiceOS
+instance over HiveMind and exposes OVOS as Home Assistant entities — media player,
+notify, sensors, switches, buttons, and a listening-mode select.
+
+- [Setup](setup.md)
+- [Configuration](configuration.md)
+- [Entities](entities.md)
+- [Permissions](permissions.md)
+
+## Where it sits
+
+Home Assistant acts as a HiveMind **client** connecting to a
+[hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core) hub that runs
+alongside an OVOS instance. Unlike a voice satellite, this integration injects
+low-level OVOS bus messages, so its client key must be admin-privileged with the
+right message-type allowlist (see [permissions](permissions.md)).
+
+## How it connects
+
+On setup the integration builds a `HiveMessageBusClient` from the configured host,
+port, access key, and password, and connects in a background task with its own
+retry/backoff. An initial connection failure is logged as a warning rather than
+being fatal, so Home Assistant keeps the device and reconnects when the hub is
+reachable.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,29 @@
+# Permissions
+
+This integration does more than send voice queries — it injects and controls OVOS
+bus messages directly. The HiveMind client it connects with must therefore have
+**admin** privileges and be allowed the specific message types it uses.
+
+## Why admin
+
+Each entity maps to OVOS bus messages: buttons/switches send control messages
+(stop, reboot, mic mute, volume, sleep), the media player sends OCP transport
+messages, and the sensors subscribe to status messages. A read-only or
+utterance-only client cannot drive these, so the client key must be admin with the
+message types allowlisted.
+
+## The allowlist
+
+The full, exact list of required message types — grouped by OVOS service
+(ovos-core, ovos-dinkum-listener, ovos-gui, ovos-audio, OCP, the optional Audio
+Service, PHAL and its alsa/system/camera plugins) — is maintained in the
+[README "Permissions Required" section](../README.md#permissions-required).
+
+Provision the HiveMind client on the hub with those message types allowed before
+adding the integration.
+
+## Security
+
+- Only connect trusted Home Assistant instances to your HiveMind hub.
+- The integration directly manipulates OVOS state; scope the client's allowlist to
+  what you actually use.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,43 @@
+# Setup
+
+## 1. Provision a HiveMind client on the hub
+
+The integration needs an **admin** client key + password on the
+`hivemind-core` hub, with the message-type allowlist from
+[permissions](permissions.md). Add the client on the hub before configuring Home
+Assistant.
+
+## 2. Install the integration
+
+Copy the `hivemind` folder into your Home Assistant `custom_components` directory:
+
+```bash
+mkdir -p /config/custom_components
+cp -r custom_components/hivemind /config/custom_components/
+```
+
+Restart Home Assistant.
+
+## 3. Add the integration
+
+In Home Assistant: **Settings → Devices & Services → Add Integration → HiveMind**.
+
+Fill in the config flow:
+
+- **Device type** — `agent`, `media_player`, or `voice_assistant` (see
+  [configuration](configuration.md)).
+- **Name** — a friendly name for the device.
+- **Host / Port** — the HiveMind hub address (e.g. `ws://192.168.1.10`, port
+  `5678`).
+- **Access key / Password** — the client credentials you provisioned in step 1.
+- **Site id**, **legacy audio**, **allow self-signed** — optional.
+
+## 4. Verify
+
+Once added, the entities for the chosen device type appear under the new HiveMind
+device (connection sensor, buttons, switches, and — depending on device type — a
+media player, notify, status sensors, and a listening-mode select). See
+[entities](entities.md).
+
+If the connection sensor stays off, check that the hub is reachable, the client key
+is admin-privileged, and the required message types are allowed.


### PR DESCRIPTION
Brings the README and `docs/` to zero-to-hero quality for hivemind-homeassistant.

- Enhances the README (kept the existing install/screenshots/permissions content): adds where-it-sits (HA as an admin HiveMind client to hivemind-core), prereqs, the full config-flow field table, the device-type → platforms map, and a docs pointer.
- Adds `docs/`: setup (provision client, install, add integration, verify), configuration (fields + device types + identity storage), entities (which entities appear per device type), permissions (why admin + pointer to the README allowlist).

Docs only — no code, version, or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
