### PR TITLE
test+ci: HA test harness, real-hub e2e, and workflows

### DIFF
--- a/.github/workflows/conventional-label.yaml
+++ b/.github/workflows/conventional-label.yaml
@@ -1,0 +1,10 @@
+# auto add labels to PRs
+on:
+  pull_request_target:
+    types: [opened, edited]
+name: conventional-release-labels
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bcoe/conventional-release-labels@v1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,21 @@
+name: E2E
+
+on:
+  push:
+    branches: [dev, master]
+  pull_request:
+    branches: [dev, master]
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      # --pre: the hivemind-core stack hivescope pulls is still prerelease
+      - run: pip install --pre -r requirements_test_e2e.txt
+      # Tier 2: the integration against a REAL loopback hivemind-core hub
+      - run: pytest tests/e2e -o norecursedirs= -q

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -1,0 +1,17 @@
+name: HACS Validation
+
+on:
+  push:
+    branches: [dev, master]
+  pull_request:
+    branches: [dev, master]
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hacs/action@main
+        with:
+          category: integration

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -1,0 +1,15 @@
+name: Hassfest
+
+on:
+  push:
+    branches: [dev, master]
+  pull_request:
+    branches: [dev, master]
+  workflow_dispatch:
+
+jobs:
+  hassfest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Lint
+
+on:
+  push:
+    branches: [dev, master]
+  pull_request:
+    branches: [dev, master]
+  workflow_dispatch:
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: pip install ruff
+      - run: ruff check custom_components tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+    branches: [dev, master]
+  pull_request:
+    branches: [dev, master]
+  workflow_dispatch:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -r requirements_test.txt
+      # Tier 1: HA harness with a fake bus — fast, no network
+      - run: pytest tests -q

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # HiveMind Integration for Home Assistant
 
-A **manual-install** Home Assistant custom integration (`domain: hivemind`) that
-connects Home Assistant to an [OpenVoiceOS](https://openvoiceos.com) instance over
-the [HiveMind](https://github.com/JarbasHiveMind/HiveMind-core) protocol and
-exposes OVOS as Home Assistant entities.
+A Home Assistant custom integration (`domain: hivemind`) that connects Home
+Assistant to an [OpenVoiceOS](https://openvoiceos.com) instance over the
+[HiveMind](https://github.com/JarbasHiveMind/HiveMind-core) protocol and exposes
+OVOS as Home Assistant entities. Installable through HACS (as a custom repository)
+or by hand.
 
 It does more than send voice commands: it controls the OVOS device at a system
 level — audio playback, volume, microphone, sleep/wake, and system power — by
@@ -26,6 +27,19 @@ must have **admin** privileges and the message-type allowlist described under
 - Home Assistant with access to its `config/custom_components/` directory.
 - The integration declares the runtime requirement `hivemind_bus_client>=0.4.3`
   (pulled in by Home Assistant on first load).
+
+## Installation
+
+**HACS (custom repository):** add `https://github.com/JarbasHiveMind/hivemind-homeassistant`
+as a custom repository (category *Integration*), install **HiveMind**, then restart
+Home Assistant.
+
+**Manual:** copy `custom_components/hivemind` into your Home Assistant
+`config/custom_components/` directory and restart.
+
+Then add it from **Settings → Devices & Services → Add Integration → HiveMind**. The
+config flow validates the hub connection before saving (clear `cannot connect` /
+`invalid auth` errors instead of a silent failure).
 
 ## Configuration fields
 

--- a/custom_components/hivemind/media_player.py
+++ b/custom_components/hivemind/media_player.py
@@ -1,17 +1,15 @@
 
 import logging
-from typing import Any, Dict
+from typing import Any
 from hivemind_bus_client.client import HiveMessageBusClient
 from hivemind_bus_client.message import HiveMessageType, HiveMessage
-from ovos_utils.log import LOG
 from homeassistant.components.media_player import (
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
-    MediaPlayerDeviceClass,
     MediaPlayerEnqueue
 )
 from homeassistant.components.media_player.const import (
-    MediaType, MediaPlayerEntityFeature, RepeatMode, MediaPlayerState, MediaClass
+    MediaType, RepeatMode, MediaPlayerState
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -22,7 +20,7 @@ from homeassistant.components.media_player.browse_media import (
 )
 
 from ovos_utils.ocp import (MediaType as OCPMediaType, MediaEntry, TrackState,
-                            PlaybackType, PlaybackMode, PlayerState, MediaState, LoopState)
+                            PlaybackType, PlayerState, MediaState, LoopState)
 
 
 from .entity import HiveMindEntity
@@ -372,13 +370,13 @@ class HiveMindMediaPlayer(HiveMindEntity, MediaPlayerEntity):
             message = Message('mycroft.audio.service.resume')
         else:
             message = Message('ovos.common_play.resume')
-        _LOGGER.info(f"play")
+        _LOGGER.info("play")
         self.send_to_ovos(message)
         self.async_write_ha_state()
 
     async def async_media_pause(self):
         self._state = MediaPlayerState.PAUSED
-        _LOGGER.info(f"pause")
+        _LOGGER.info("pause")
         if self.legacy_audioservice:
             message = Message('mycroft.audio.service.pause')
         else:
@@ -389,7 +387,7 @@ class HiveMindMediaPlayer(HiveMindEntity, MediaPlayerEntity):
 
     async def async_media_stop(self):
         self._state = MediaPlayerState.IDLE
-        _LOGGER.info(f"stop")
+        _LOGGER.info("stop")
         if self.legacy_audioservice:
             message = Message('mycroft.audio.service.stop')
         else:
@@ -478,7 +476,7 @@ class HiveMindMediaPlayer(HiveMindEntity, MediaPlayerEntity):
         """Clear players playlist."""
         message = Message('ovos.common_play.playlist.clear')
         self.send_to_ovos(message)
-        _LOGGER.info(f"clear playlist")
+        _LOGGER.info("clear playlist")
         self.async_write_ha_state()
 
     async def async_set_shuffle(self, shuffle: bool) -> None:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,12 @@ the integration; there is no YAML.
 
 ## Identity storage
 
-The integration writes its HiveMind node identity to `_identity.json` inside the
-installed `custom_components/hivemind/` package directory. The bus uses a fixed
-session id (`default`) so the hub does not assign a random session per connection.
+The integration stores its HiveMind node identity under Home Assistant's
+configuration directory (`<config>/hivemind/<entry_id>/_identity.json`), created on
+first connection. It is kept out of the `custom_components/` package directory so it
+survives upgrades and never needs to write there at runtime.
+
+The bus uses a fixed session id (`default`) so the hub does not assign a random
+session per connection. `hivemind-core` only allows the `default` session for
+**admin** clients — which is why the client must be provisioned with `--admin`
+(see [permissions](permissions.md)).

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -12,6 +12,15 @@ messages, and the sensors subscribe to status messages. A read-only or
 utterance-only client cannot drive these, so the client key must be admin with the
 message types allowlisted.
 
+Concretely, the integration pins the `default` OVOS session so the hub does not
+assign a random session per reconnection — and `hivemind-core` only permits the
+`default` session for admin clients. A non-admin client is rejected from that
+session, so provision the client with `--admin`:
+
+```bash
+hivemind-core add-client --admin
+```
+
 ## The allowlist
 
 The full, exact list of required message types — grouped by OVOS service

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -32,6 +32,10 @@ Fill in the config flow:
 - **Access key / Password** — the client credentials you provisioned in step 1.
 - **Site id**, **legacy audio**, **allow self-signed** — optional.
 
+The form checks the connection before it is saved: if the hub is unreachable you
+get **"cannot connect"**, and if it rejects the credentials you get **"invalid
+auth"** — so you find out immediately rather than from a silent failure later.
+
 ## 4. Verify
 
 Once added, the entities for the chosen device type appear under the new HiveMind

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,5 @@
+{
+  "name": "HiveMind",
+  "render_readme": true,
+  "homeassistant": "2024.1.0"
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests
+norecursedirs = tests/e2e

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,7 @@
+# Tier 1 test dependencies (no network): the HA test harness plus the
+# integration's own runtime requirements so the component imports.
+pytest-homeassistant-custom-component
+hivemind_bus_client>=0.4.3
+ovos-bus-client
+ovos-utils
+json_database

--- a/requirements_test_e2e.txt
+++ b/requirements_test_e2e.txt
@@ -1,0 +1,5 @@
+# Tier 2 (real-hub) e2e dependencies. Install with --pre: the hivemind-core
+# stack hivescope pulls in is still prerelease (2.x migration). hivescope is
+# pinned to the loopback-whitelist branch until that fix is released.
+-r requirements_test.txt
+hivescope @ git+https://github.com/JarbasHiveMind/hivescope.git@fix/loopback-whitelist-only-connection

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Shared pytest fixtures for the HiveMind integration tests."""
+
+import pytest
+
+pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Enable loading custom_components/hivemind in every test."""
+    yield

--- a/tests/e2e/test_ha_integration_e2e.py
+++ b/tests/e2e/test_ha_integration_e2e.py
@@ -1,0 +1,122 @@
+"""REAL end-to-end test for the HiveMind Home Assistant integration.
+
+Drives the integration's *actual* code path against a *real* hivemind-core hub
+running over a real localhost WebSocket (hivescope's loopback master). Nothing
+about the HiveMind connection is mocked: the integration builds its own
+``HiveMessageBusClient``, performs the encrypted handshake, is admitted by the
+hub's deny-by-default ACL, and exchanges real messages.
+
+  Home Assistant config entry
+    -> async_setup_entry -> get_bus -> HiveMessageBusClient.connect()  [WebSocket]
+    -> real hivemind-core hub: handshake, encryption, whitelist ACL
+    -> connection binary_sensor reports "on"
+    -> notify.send_message -> emit("speak")                            [WebSocket]
+    -> hub admits it and injects it onto the agent bus
+"""
+
+import time
+from urllib.parse import urlparse
+
+import custom_components.hivemind  # noqa: F401 - ensure HA can discover the integration
+import pytest
+from homeassistant.setup import async_setup_component
+from hivescope.topology import TopologyBuilder
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+SAT_KEY = "ha-key"
+SAT_PASSWORD = "ha-password"
+# the message types the integration actually emits that we assert on
+ALLOWED = [
+    "mycroft.stop",
+    "speak",
+    "mycroft.skills.is_alive",
+    "mycroft.audio.speak.status",
+    "recognizer_loop:state.get",
+]
+
+
+def _entry_data(url: str) -> dict:
+    parsed = urlparse(url)
+    return {
+        "device_type": "voice_assistant",
+        "name": "E2E Room",
+        "host": f"ws://{parsed.hostname}",
+        "access_key": SAT_KEY,
+        "password": SAT_PASSWORD,
+        "port": parsed.port,
+        "legacy_audio": False,
+        "site_id": "e2e",
+        "allow_self_signed": False,
+    }
+
+
+async def _wait_handshake(hass, bus, timeout=15):
+    await hass.async_add_executor_job(
+        getattr(bus, "wait_for_handshake", lambda t: None), timeout
+    )
+    deadline = time.monotonic() + timeout
+    while not bus.handshake_event.is_set() and time.monotonic() < deadline:
+        await hass.async_add_executor_job(time.sleep, 0.1)
+
+
+@pytest.mark.asyncio
+async def test_integration_connects_to_real_hub_and_speaks(hass, socket_enabled):
+    # register core services (homeassistant.update_entity, button.press, ...)
+    await async_setup_component(hass, "homeassistant", {})
+    await async_setup_component(hass, "button", {})
+
+    builder = TopologyBuilder()
+    master = builder.add_master("M0", use_loopback=True)
+    # the integration pins the "default" session, which hivemind-core only
+    # allows for admin clients (this is why the docs say to add the client with
+    # --admin), so register an admin satellite here.
+    master.register_satellite(
+        SAT_KEY, password=SAT_PASSWORD, is_admin=True, allowed_types=ALLOWED
+    )
+    builder.start_all()
+
+    entry = MockConfigEntry(
+        domain="hivemind",
+        data=_entry_data(master.network_protocol.url),
+        entry_id="e2e",
+    )
+    entry.add_to_hass(hass)
+
+    try:
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        bus = entry.runtime_data.bus
+        await _wait_handshake(hass, bus)
+        assert bus.handshake_event.is_set(), "integration never handshook with the hub"
+
+        # the hub registers the peer just after the handshake; poll briefly
+        deadline = time.monotonic() + 10
+        while not master.connected_peers() and time.monotonic() < deadline:
+            await hass.async_add_executor_job(time.sleep, 0.1)
+        assert len(master.connected_peers()) == 1, "hub did not see the satellite"
+
+        # the connection binary_sensor reflects the real connection
+        conn = next(
+            e for e in hass.states.async_entity_ids("binary_sensor")
+            if "connection" in e
+        )
+        await hass.services.async_call(
+            "homeassistant", "update_entity", {"entity_id": conn}, blocking=True
+        )
+        assert hass.states.get(conn).state == "on"
+
+        # outbound: pressing the Stop button really crosses the hub to its
+        # agent bus (a full HA-service -> entity -> WebSocket -> hub round-trip)
+        stop_id = next(
+            e for e in hass.states.async_entity_ids("button") if "stop" in e
+        )
+        await hass.services.async_call(
+            "button", "press", {"entity_id": stop_id}, blocking=True
+        )
+        await hass.async_add_executor_job(time.sleep, 1)
+        master.agent_protocol.assert_injected("mycroft.stop", count=1)
+    finally:
+        await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+        builder.stop_all()

--- a/tests/fake_bus.py
+++ b/tests/fake_bus.py
@@ -1,0 +1,65 @@
+"""A fake HiveMessageBusClient for tests that need no real hub.
+
+It records emitted messages and lets a test fire bus events into the handlers
+the entities registered, so entity state logic can be exercised deterministically.
+"""
+
+import threading
+
+from ovos_bus_client.message import Message
+
+
+class FakeHiveBus:
+    """Drop-in stand-in for HiveMessageBusClient (the bits the integration uses)."""
+
+    def __init__(self, *, connected: bool = True) -> None:
+        self.handshake_event = threading.Event()
+        self.connected_event = threading.Event()
+        # whether a later connect() call is allowed to complete the handshake
+        self._connectable = connected
+        if connected:
+            self.handshake_event.set()
+            self.connected_event.set()
+        self._host = "ws://testhub"
+        self.site_id = "test"
+        self.protocol = object()
+        self.crypto_key = b"k"
+        self.handlers: dict[str, list] = {}
+        self.emitted: list = []
+
+    # -- registration ---------------------------------------------------------
+    def on_mycroft(self, event: str, handler) -> None:
+        self.handlers.setdefault(event, []).append(handler)
+
+    def remove(self, event: str, handler) -> None:
+        if handler in self.handlers.get(event, []):
+            self.handlers[event].remove(handler)
+
+    # -- emission -------------------------------------------------------------
+    def emit_mycroft(self, message) -> None:
+        self.emitted.append(message)
+
+    def emit(self, message) -> None:
+        self.emitted.append(message)
+
+    # -- lifecycle ------------------------------------------------------------
+    def connect(self, *args, **kwargs) -> None:
+        if self._connectable:
+            self.handshake_event.set()
+            self.connected_event.set()
+
+    def close(self) -> None:
+        self.handshake_event.clear()
+        self.connected_event.clear()
+
+    def wait_for_handshake(self, timeout: float = 0) -> bool:
+        return self.handshake_event.is_set()
+
+    # -- test helpers ---------------------------------------------------------
+    def inject(self, event: str, data: dict | None = None) -> None:
+        """Fire a bus event into every handler registered for it."""
+        for handler in list(self.handlers.get(event, [])):
+            handler(Message(event, data or {}))
+
+    def handler_count(self, event: str) -> int:
+        return len(self.handlers.get(event, []))

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,74 @@
+"""Config-flow tests: connection validation, errors, and duplicate guard."""
+
+from unittest.mock import patch
+
+import custom_components.hivemind as hivemind
+import custom_components.hivemind.config_flow as config_flow
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from .fake_bus import FakeHiveBus
+
+USER_INPUT = {
+    "device_type": "voice_assistant",
+    "name": "Living Room",
+    "host": "ws://127.0.0.1",
+    "access_key": "key",
+    "password": "pw",
+    "port": 5678,
+    "legacy_audio": False,
+    "site_id": "test",
+    "allow_self_signed": False,
+}
+
+
+async def _submit(hass, *, handshake_ok=True, raises=False):
+    def _fake_validate(data):
+        if raises:
+            raise ConnectionError("boom")
+        return handshake_ok
+
+    result = await hass.config_entries.flow.async_init(
+        "hivemind", context={"source": "user"}
+    )
+    # a completed flow also *sets up* the entry, so stub the runtime bus too
+    with (
+        patch.object(config_flow, "_try_handshake", side_effect=_fake_validate),
+        patch.object(hivemind, "_build_bus", return_value=FakeHiveBus()),
+    ):
+        out = await hass.config_entries.flow.async_configure(
+            result["flow_id"], USER_INPUT
+        )
+        await hass.async_block_till_done()
+    return out
+
+
+async def test_happy_path_creates_entry(hass):
+    result = await _submit(hass, handshake_ok=True)
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Living Room"
+    assert result["data"]["host"] == "ws://127.0.0.1"
+
+
+async def test_bad_credentials_show_invalid_auth(hass):
+    result = await _submit(hass, handshake_ok=False)
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_unreachable_hub_shows_cannot_connect(hass):
+    result = await _submit(hass, raises=True)
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_duplicate_hub_is_aborted(hass):
+    MockConfigEntry(
+        domain="hivemind",
+        data=USER_INPUT,
+        unique_id="ws://127.0.0.1-key",
+    ).add_to_hass(hass)
+
+    result = await _submit(hass, handshake_ok=True)
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,0 +1,130 @@
+"""Entity state-handler logic and regressions for the fixed bugs."""
+
+import asyncio
+from unittest.mock import patch
+
+import custom_components.hivemind as hivemind
+from custom_components.hivemind.button import HiveMindConnectionButton
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from .fake_bus import FakeHiveBus
+
+DATA = {
+    "device_type": "voice_assistant",
+    "name": "Living Room",
+    "host": "ws://127.0.0.1",
+    "access_key": "key",
+    "password": "pw",
+    "port": 5678,
+    "legacy_audio": False,
+    "site_id": "test",
+    "allow_self_signed": False,
+}
+
+
+async def _setup(hass, fake):
+    entry = MockConfigEntry(domain="hivemind", data=DATA, entry_id="ent")
+    entry.add_to_hass(hass)
+    with patch.object(hivemind, "_build_bus", return_value=fake):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def _one(hass, platform):
+    ids = hass.states.async_entity_ids(platform)
+    assert ids, f"no {platform} entity"
+    return ids[0]
+
+
+async def test_track_info_keeps_artist_and_album_separate(hass):
+    """Regression: album used to overwrite the artist field."""
+    fake = FakeHiveBus()
+    await _setup(hass, fake)
+    mp = _one(hass, "media_player")
+
+    fake.inject(
+        "ovos.common_play.track_info.response",
+        {"title": "Song", "artist": "The Artist", "album": "The Album"},
+    )
+    await hass.async_block_till_done()
+
+    attrs = hass.states.get(mp).attributes
+    assert attrs.get("media_artist") == "The Artist"
+    assert attrs.get("media_album_name") == "The Album"
+
+
+async def test_player_state_maps_to_media_state(hass):
+    fake = FakeHiveBus()
+    await _setup(hass, fake)
+    mp = _one(hass, "media_player")
+
+    from ovos_utils.ocp import PlayerState
+
+    fake.inject("ovos.common_play.player.state", {"state": PlayerState.PLAYING})
+    await hass.async_block_till_done()
+    assert hass.states.get(mp).state == "playing"
+
+
+async def test_malformed_ocp_status_does_not_raise(hass):
+    """Regression: handlers used message.data[...] and raised KeyError."""
+    fake = FakeHiveBus()
+    await _setup(hass, fake)
+    # empty payloads must not blow up any handler
+    for event in (
+        "ovos.common_play.player.status.response",
+        "ovos.common_play.media.state",
+        "ovos.common_play.get_track_length.response",
+        "mycroft.volume.get.response",
+    ):
+        fake.inject(event, {})
+    await hass.async_block_till_done()
+
+
+async def test_listener_sensor_has_no_state_class_and_updates(hass):
+    """Regression: an enum sensor must not carry a MEASUREMENT state_class."""
+    fake = FakeHiveBus()
+    await _setup(hass, fake)
+    sensor = _one(hass, "sensor")
+
+    state = hass.states.get(sensor)
+    assert state.attributes.get("state_class") is None
+    assert state.attributes.get("device_class") == "enum"
+
+    fake.inject("recognizer_loop:state", {"state": "continuous"})
+    await hass.async_block_till_done()
+    assert hass.states.get(sensor).state == "continuous"
+
+
+async def test_alive_sensor_reflects_status(hass):
+    fake = FakeHiveBus()
+    await _setup(hass, fake)
+
+    skills_alive = [
+        e for e in hass.states.async_entity_ids("binary_sensor")
+        if "ovos_core_alive" in e or "alive" in e
+    ]
+    assert skills_alive
+    # fire an is_alive response for every alive sensor's service
+    for event in list(fake.handlers):
+        if event.endswith("is_alive.response"):
+            fake.inject(event, {"status": True})
+    await hass.async_block_till_done()
+    assert any(hass.states.get(e).state == "on" for e in skills_alive)
+
+
+async def test_connection_sensor_available_even_when_disconnected(hass):
+    fake = FakeHiveBus(connected=False)
+    await _setup(hass, fake)
+    conn = [
+        e for e in hass.states.async_entity_ids("binary_sensor")
+        if "connection" in e
+    ]
+    assert conn
+    # not "unavailable": the connectivity sensor stays visible, just off
+    assert hass.states.get(conn[0]).state == "off"
+
+
+def test_reconnect_button_is_async():
+    """Regression: the reconnect press ran blocking I/O on the event loop."""
+    assert asyncio.iscoroutinefunction(HiveMindConnectionButton.async_press)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,82 @@
+"""Setup/unload/reload behaviour of the integration."""
+
+from unittest.mock import patch
+
+import custom_components.hivemind as hivemind
+import pytest
+from homeassistant.config_entries import ConfigEntryState
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from .fake_bus import FakeHiveBus
+
+BASE_DATA = {
+    "name": "Living Room",
+    "host": "ws://127.0.0.1",
+    "access_key": "key",
+    "password": "pw",
+    "port": 5678,
+    "legacy_audio": False,
+    "site_id": "test",
+    "allow_self_signed": False,
+}
+
+
+async def _setup(hass, fake, device_type):
+    entry = MockConfigEntry(
+        domain="hivemind",
+        data={**BASE_DATA, "device_type": device_type},
+        entry_id=f"e-{device_type}",
+    )
+    entry.add_to_hass(hass)
+    with patch.object(hivemind, "_build_bus", return_value=fake):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+@pytest.mark.parametrize(
+    ("device_type", "expected", "absent"),
+    [
+        ("agent", {"binary_sensor", "button", "switch"},
+         {"media_player", "notify", "select", "sensor"}),
+        ("media_player", {"binary_sensor", "button", "switch", "media_player"},
+         {"select", "sensor"}),
+        ("voice_assistant",
+         {"binary_sensor", "button", "switch", "media_player", "sensor", "select"},
+         set()),
+    ],
+)
+async def test_platforms_per_device_type(hass, device_type, expected, absent):
+    fake = FakeHiveBus()
+    await _setup(hass, fake, device_type)
+    for platform in expected:
+        assert hass.states.async_entity_ids(platform), f"missing {platform}"
+    for platform in absent:
+        assert not hass.states.async_entity_ids(platform), f"unexpected {platform}"
+
+
+async def test_unload_closes_bus_and_clears_data(hass):
+    fake = FakeHiveBus()
+    entry = await _setup(hass, fake, "agent")
+    assert hass.data["hivemind"].get(entry.entry_id) is not None
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    assert not fake.handshake_event.is_set()  # close() was called
+    assert hass.data["hivemind"].get(entry.entry_id) is None
+
+
+async def test_reload_does_not_duplicate_handlers(hass):
+    fake = FakeHiveBus()
+    entry = await _setup(hass, fake, "voice_assistant")
+    before = fake.handler_count("recognizer_loop:state")
+    assert before >= 1
+
+    with patch.object(hivemind, "_build_bus", return_value=fake):
+        assert await hass.config_entries.async_reload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    # handlers removed on unload then re-added once — not stacked
+    assert fake.handler_count("recognizer_loop:state") == before

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,60 @@
+"""Smoke test: the integration sets up, exposes entities, and unloads cleanly."""
+
+from unittest.mock import patch
+
+import custom_components.hivemind as hivemind
+from homeassistant.config_entries import ConfigEntryState
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from .fake_bus import FakeHiveBus
+
+ENTRY_DATA = {
+    "device_type": "voice_assistant",
+    "name": "Living Room",
+    "host": "ws://127.0.0.1",
+    "access_key": "key",
+    "password": "pw",
+    "port": 5678,
+    "legacy_audio": False,
+    "site_id": "test",
+    "allow_self_signed": False,
+}
+
+
+async def _setup(hass, fake):
+    entry = MockConfigEntry(domain="hivemind", data=ENTRY_DATA, entry_id="t1")
+    entry.add_to_hass(hass)
+    with patch.object(hivemind, "_build_bus", return_value=fake):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+async def test_setup_creates_entities_and_unloads(hass):
+    fake = FakeHiveBus(connected=True)
+    entry = await _setup(hass, fake)
+
+    assert entry.state is ConfigEntryState.LOADED
+    # entities across the expected platforms exist
+    assert hass.states.async_entity_ids("binary_sensor")
+    assert hass.states.async_entity_ids("media_player")
+    assert hass.states.async_entity_ids("switch")
+    assert hass.states.async_entity_ids("button")
+    assert hass.states.async_entity_ids("sensor")
+    assert hass.states.async_entity_ids("select")
+
+    # the connection sensor reports connected
+    conn = [
+        s for s in hass.states.async_all("binary_sensor")
+        if "connection" in s.entity_id
+    ]
+    assert conn and conn[0].state == "on"
+
+    # handlers were registered on the bus
+    assert fake.handler_count("ovos.common_play.player.state") >= 1
+
+    # unload removes the entry and every bus handler it registered
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    assert all(len(v) == 0 for v in fake.handlers.values())


### PR DESCRIPTION
Phase 3 — tests and CI. **Stacked on #6.**

## Tests
- **Tier 1 (no network)** — `pytest-homeassistant-custom-component` with a fake
  bus: config-flow validation paths, setup/unload per device type, a reload that
  must not duplicate handlers, and per-entity state logic, plus regressions for
  every bug fixed in #5.
- **Tier 2 (`tests/e2e`)** — the integration drives its **real** client against
  a **real** `hivemind-core` hub booted in-process by hivescope over a loopback
  WebSocket: real handshake, ACL admission, peer registration, the connection
  sensor flipping on, and a `button.press` round-trip onto the hub's agent bus.
  This also confirmed the integration needs an **admin** client (it pins the
  `default` session, which hivemind-core only allows for admins).

Locally: Tier 1 17 passed, e2e 1 passed, ruff clean (HA 2026.2, py3.13).

## CI
- `hassfest`, `hacs` (validation), `lint` (ruff), `tests` (Tier 1), `e2e`
  (Tier 2), and `conventional-label`.
- `hacs.json` so the integration installs from HACS.
- gh-automations `repo-health` is **not** wired: it requires a `version_file`
  (PyPI packages); an HA integration versions via `manifest.json`.