### PR TITLE
docs: match the modernized setup, identity storage, and admin requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # HiveMind Integration for Home Assistant
 
-A **manual-install** Home Assistant custom integration (`domain: hivemind`) that
-connects Home Assistant to an [OpenVoiceOS](https://openvoiceos.com) instance over
-the [HiveMind](https://github.com/JarbasHiveMind/HiveMind-core) protocol and
-exposes OVOS as Home Assistant entities.
+A Home Assistant custom integration (`domain: hivemind`) that connects Home
+Assistant to an [OpenVoiceOS](https://openvoiceos.com) instance over the
+[HiveMind](https://github.com/JarbasHiveMind/HiveMind-core) protocol and exposes
+OVOS as Home Assistant entities. Installable through HACS (as a custom repository)
+or by hand.
 
 It does more than send voice commands: it controls the OVOS device at a system
 level — audio playback, volume, microphone, sleep/wake, and system power — by
@@ -26,6 +27,19 @@ must have **admin** privileges and the message-type allowlist described under
 - Home Assistant with access to its `config/custom_components/` directory.
 - The integration declares the runtime requirement `hivemind_bus_client>=0.4.3`
   (pulled in by Home Assistant on first load).
+
+## Installation
+
+**HACS (custom repository):** add `https://github.com/JarbasHiveMind/hivemind-homeassistant`
+as a custom repository (category *Integration*), install **HiveMind**, then restart
+Home Assistant.
+
+**Manual:** copy `custom_components/hivemind` into your Home Assistant
+`config/custom_components/` directory and restart.
+
+Then add it from **Settings → Devices & Services → Add Integration → HiveMind**. The
+config flow validates the hub connection before saving (clear `cannot connect` /
+`invalid auth` errors instead of a silent failure).
 
 ## Configuration fields
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,12 @@ the integration; there is no YAML.
 
 ## Identity storage
 
-The integration writes its HiveMind node identity to `_identity.json` inside the
-installed `custom_components/hivemind/` package directory. The bus uses a fixed
-session id (`default`) so the hub does not assign a random session per connection.
+The integration stores its HiveMind node identity under Home Assistant's
+configuration directory (`<config>/hivemind/<entry_id>/_identity.json`), created on
+first connection. It is kept out of the `custom_components/` package directory so it
+survives upgrades and never needs to write there at runtime.
+
+The bus uses a fixed session id (`default`) so the hub does not assign a random
+session per connection. `hivemind-core` only allows the `default` session for
+**admin** clients — which is why the client must be provisioned with `--admin`
+(see [permissions](permissions.md)).

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -12,6 +12,15 @@ messages, and the sensors subscribe to status messages. A read-only or
 utterance-only client cannot drive these, so the client key must be admin with the
 message types allowlisted.
 
+Concretely, the integration pins the `default` OVOS session so the hub does not
+assign a random session per reconnection — and `hivemind-core` only permits the
+`default` session for admin clients. A non-admin client is rejected from that
+session, so provision the client with `--admin`:
+
+```bash
+hivemind-core add-client --admin
+```
+
 ## The allowlist
 
 The full, exact list of required message types — grouped by OVOS service

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -32,6 +32,10 @@ Fill in the config flow:
 - **Access key / Password** — the client credentials you provisioned in step 1.
 - **Site id**, **legacy audio**, **allow self-signed** — optional.
 
+The form checks the connection before it is saved: if the hub is unreachable you
+get **"cannot connect"**, and if it rejects the credentials you get **"invalid
+auth"** — so you find out immediately rather than from a silent failure later.
+
 ## 4. Verify
 
 Once added, the entities for the chosen device type appear under the new HiveMind


### PR DESCRIPTION
Phase 4 — docs. **Stacked on #7.**

- Identity is stored under Home Assistant's config dir, not the package dir.
- The config flow validates the hub connection up front (`cannot_connect` /
  `invalid_auth`).
- Explain *why* the client must be admin: the integration pins the `default`
  session, which `hivemind-core` only allows for admin clients (confirmed by the
  e2e in #7).
- Document HACS (custom repository) installation alongside the manual copy.

The existing permissions/allow-msg matrix was already accurate and is kept; the
e2e's `allowed_types` agree with it.