### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,87 +3,45 @@
 A Home Assistant custom integration (`domain: hivemind`) that connects Home
 Assistant to an [OpenVoiceOS](https://openvoiceos.com) instance over the
 [HiveMind](https://github.com/JarbasHiveMind/HiveMind-core) protocol and exposes
-OVOS as Home Assistant entities. Installable through HACS (as a custom repository)
-or by hand.
+OVOS as Home Assistant entities. You can install it through HACS (as a custom
+repository) or by hand.
 
-It does more than send voice commands: it controls the OVOS device at a system
-level — audio playback, volume, microphone, sleep/wake, and system power — by
-injecting low-level bus messages over the HiveMind link.
+The integration does more than send voice commands. It controls the OVOS device
+at a system level: audio playback, volume, microphone, sleep and wake, and
+system power. It does this by injecting low-level bus messages over the
+HiveMind link.
 
 ## Where it sits
 
 Home Assistant connects to a HiveMind hub
-([hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core)) running
+([hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core)) that runs
 alongside an OVOS instance, using a HiveMind **client key**. Because the
-integration injects low-level bus messages rather than just utterances, that client
-must have **admin** privileges and the message-type allowlist described under
-[Permissions Required](#permissions-required).
+integration injects low-level bus messages instead of only utterances, that
+client must have **admin** privileges and the message-type allowlist described
+under [Permissions Required](#permissions-required).
 
 ## Prerequisites
 
 - A running HiveMind hub (`hivemind-core`) reachable from Home Assistant.
-- An admin-privileged HiveMind client key + password registered on the hub for
-  Home Assistant (see [Permissions Required](#permissions-required)).
+- An admin-privileged HiveMind client key and password registered on the hub
+  for Home Assistant (see [Permissions Required](#permissions-required)).
 - Home Assistant with access to its `config/custom_components/` directory.
-- The integration declares the runtime requirement `hivemind_bus_client>=0.4.3`
-  (pulled in by Home Assistant on first load).
+- The integration declares the runtime requirement `hivemind_bus_client>=0.4.3`,
+  which Home Assistant installs on first load.
 
 ## Installation
 
-**HACS (custom repository):** add `https://github.com/JarbasHiveMind/hivemind-homeassistant`
-as a custom repository (category *Integration*), install **HiveMind**, then restart
-Home Assistant.
+### HACS (custom repository)
 
-**Manual:** copy `custom_components/hivemind` into your Home Assistant
-`config/custom_components/` directory and restart.
+1. Add `https://github.com/JarbasHiveMind/hivemind-homeassistant` as a custom
+   repository (category *Integration*).
+2. Install **HiveMind**.
+3. Restart Home Assistant.
 
-Then add it from **Settings → Devices & Services → Add Integration → HiveMind**. The
-config flow validates the hub connection before saving (clear `cannot connect` /
-`invalid auth` errors instead of a silent failure).
+### Manual
 
-## Configuration fields
-
-When you add the integration (Settings → Devices & Services → Add Integration →
-HiveMind), the config flow asks for:
-
-| Field | Default | Description |
-| --- | --- | --- |
-| `device_type` | `voice_assistant` | Which OVOS capabilities to expose (see below). |
-| `name` | — | Friendly name for the device in Home Assistant. |
-| `host` | — | HiveMind hub host (e.g. `ws://192.168.1.10`). |
-| `access_key` | — | HiveMind client access key. |
-| `password` | — | HiveMind client password. |
-| `port` | `5678` | HiveMind WebSocket port. |
-| `legacy_audio` | `false` | Use the legacy Audio Service instead of OCP. |
-| `site_id` | `unknown` | OVOS site id. |
-| `allow_self_signed` | `false` | Accept a self-signed TLS certificate. |
-
-### Device types
-
-The `device_type` controls which platforms are set up:
-
-| Type | Exposes |
-| --- | --- |
-| `agent` | binary sensors, buttons, switches (text I/O only). |
-| `media_player` | the above + `notify` + `media_player`. |
-| `voice_assistant` | the above + `select` + `sensor` (full mic/VAD/STT device). |
-
-See [`docs/`](docs/index.md) for the full setup, entity, and permissions walkthrough.
-
----
-
-## Related Projects:
-
-- [hivemind-homeassistant](https://github.com/JarbasHiveMind/hivemind-homeassistant) (this repo) allows HiveMind to show up as a player in Home Assistant
-- [hivemind-player-protocol](https://github.com/HiveMindInsiders/hivemind-player-protocol) turn any device into a standalone HiveMind OCP player
-- [ovos-skill-music-assistant](https://github.com/HiveMindInsiders/ovos-skill-music-assistant) allows OVOS to search media in MA sources
-- [ovos-media-plugin-mass](https://github.com/HiveMindInsiders/ovos-media-plugin-mass) allows OVOS to control MA players
-  
----
-
-## Manual Installation
-
-1. Copy the `hivemind` folder into your Home Assistant `custom_components` directory:
+1. Copy the `hivemind` folder into your Home Assistant
+   `custom_components` directory:
 
    ```bash
    mkdir -p /config/custom_components
@@ -92,48 +50,63 @@ See [`docs/`](docs/index.md) for the full setup, entity, and permissions walkthr
 
 2. Restart Home Assistant.
 
-3. Add the HiveMind integration via the Home Assistant UI:  
-   **Settings → Devices & Services → Add Integration → HiveMind**
+### Add the integration
 
----
+Go to **Settings → Devices & Services → Add Integration → HiveMind**. The
+config flow checks the hub connection before it saves the entry, so a bad host
+or credential shows a clear `cannot connect` or `invalid auth` error instead of
+a silent failure.
 
-## Home Assistant Setup
+## Configuration fields
 
-![setup](https://github.com/user-attachments/assets/5b34c714-3faa-4c8b-8c84-e438c20085fb)
+The config flow asks for these fields when you add the integration:
 
-Once a HiveMind device is added to HomeAssistant you will have several entities available
+| Field | Default | Description |
+| --- | --- | --- |
+| `device_type` | `voice_assistant` | Which OVOS capabilities to expose (see below). |
+| `name` | n/a | Friendly name for the device in Home Assistant. |
+| `host` | n/a | HiveMind hub host (e.g. `ws://192.168.1.10`). |
+| `access_key` | n/a | HiveMind client access key. |
+| `password` | n/a | HiveMind client password. |
+| `port` | `5678` | HiveMind WebSocket port. |
+| `legacy_audio` | `false` | Use the legacy Audio Service instead of OCP. |
+| `site_id` | `unknown` | OVOS site id. |
+| `allow_self_signed` | `false` | Accept a self-signed TLS certificate. |
 
-![image](https://github.com/user-attachments/assets/f4a56e28-96e1-470e-99cc-0f9e8707b37f)
+### Device types
 
-controls
+The `device_type` field controls which platforms Home Assistant sets up:
 
-![image](https://github.com/user-attachments/assets/d76cd0a6-7dc1-4af8-93d3-73668e11a405)
+| Type | Exposes |
+| --- | --- |
+| `agent` | binary sensors, buttons, switches (text input and output only). |
+| `media_player` | the above, plus `notify` and `media_player`. |
+| `voice_assistant` | the above, plus `select` and `sensor` (full mic, VAD, and STT device). |
 
-media player
+See [`docs/`](docs/index.md) for the full setup, entity, and permissions guide.
 
-![image](https://github.com/user-attachments/assets/9bb3bdba-bce0-47f5-b837-6f934eff67ef)
+## Usage
 
-notify
+Once you add a HiveMind device, its entities appear in Home Assistant: a
+connection sensor, control buttons and switches, and — depending on
+`device_type` — a media player, a notify service, status sensors, and a
+listening-mode selector.
 
-![image](https://github.com/user-attachments/assets/57a797f7-06a6-4d12-9eb0-a3496fe32748)
+![Home Assistant entities](https://github.com/user-attachments/assets/f4a56e28-96e1-470e-99cc-0f9e8707b37f)
 
-status sensors
+Send text to the OVOS instance with the `notify` service so it speaks the text
+through TTS. Control playback with the `media_player` entity, which maps Home
+Assistant `MediaType` values to OVOS OCP media types (music, video, movie,
+episode, TV channel, game, and others). It also works with sources exposed by
+[ovos-skill-music-assistant](https://github.com/HiveMindInsiders/ovos-skill-music-assistant).
 
-![image](https://github.com/user-attachments/assets/5f98232b-1243-445f-98ed-bb03e23a50b5)
-
-
-## Music Assistant
-
-![image](https://github.com/user-attachments/assets/1b0adcb0-bb92-4125-82ee-36367ce2bf60)
-
-
----
+![Media player entity](https://github.com/user-attachments/assets/9bb3bdba-bce0-47f5-b837-6f934eff67ef)
 
 ## Permissions Required
 
-Since this integration does **more than just voice queries**, it requires **low-level permissions** to inject and control bus messages directly.  
-
-The client connecting to HiveMind must have **admin privileges** and permission to access the following message types:
+This integration does more than send voice queries: it injects and controls
+bus messages directly. The client connecting to HiveMind must have **admin**
+privileges and permission to use the following message types.
 
 ### ovos-core
 - `mycroft.stop`
@@ -182,7 +155,7 @@ The client connecting to HiveMind must have **admin privileges** and permission 
 - `ovos.common_play.repeat.one`
 
 #### Audio Service
-*(only if enabled manually — for systems without the OCP Audio Plugin)*
+*(only if you enable it manually, for systems without the OCP Audio Plugin)*
 
 - `mycroft.audio.service.play`
 - `mycroft.audio.service.resume`
@@ -211,18 +184,26 @@ The client connecting to HiveMind must have **admin privileges** and permission 
 
 #### ovos-phal-plugin-camera
 
-(*work in progress*)
+*(work in progress)*
 
 - `ovos.phal.camera.ping`
 - `ovos.phal.camera.get`
 - `ovos.phal.camera.open`
 - `ovos.phal.camera.close`
 
----
+### Security notes
 
-## Notes
-
-- This integration **directly manipulates OpenVoiceOS** state
+- This integration directly manipulates OpenVoiceOS state.
 - Proper permission management is critical for security.
-- Only trusted Home Assistant instances should connect to your HiveMind server.
+- Only connect trusted Home Assistant instances to your HiveMind hub.
 
+## Related Projects
+
+- [hivemind-homeassistant](https://github.com/JarbasHiveMind/hivemind-homeassistant) (this repo) lets HiveMind show up as a player in Home Assistant.
+- [hivemind-player-protocol](https://github.com/HiveMindInsiders/hivemind-player-protocol) turns any device into a standalone HiveMind OCP player.
+- [ovos-skill-music-assistant](https://github.com/HiveMindInsiders/ovos-skill-music-assistant) lets OVOS search media in Music Assistant sources.
+- [ovos-media-plugin-mass](https://github.com/HiveMindInsiders/ovos-media-plugin-mass) lets OVOS control Music Assistant players.
+
+## License
+
+[MIT](LICENSE)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,17 +1,17 @@
 # Configuration
 
-Configuration is done entirely through the Home Assistant config flow when adding
-the integration; there is no YAML.
+You do all configuration through the Home Assistant config flow when you add
+the integration. There is no YAML.
 
 ## Fields
 
 | Field | Default | Description |
 | --- | --- | --- |
 | `device_type` | `voice_assistant` | Which OVOS capabilities to expose. |
-| `name` | — | Friendly name for the device in Home Assistant. |
-| `host` | — | HiveMind hub host (e.g. `ws://192.168.1.10`). |
-| `access_key` | — | HiveMind client access key. |
-| `password` | — | HiveMind client password. |
+| `name` | n/a | Friendly name for the device in Home Assistant. |
+| `host` | n/a | HiveMind hub host (e.g. `ws://192.168.1.10`). |
+| `access_key` | n/a | HiveMind client access key. |
+| `password` | n/a | HiveMind client password. |
 | `port` | `5678` | HiveMind WebSocket port. |
 | `legacy_audio` | `false` | Use the legacy Audio Service instead of OCP for playback. |
 | `site_id` | `unknown` | OVOS site id. |
@@ -30,11 +30,15 @@ the integration; there is no YAML.
 ## Identity storage
 
 The integration stores its HiveMind node identity under Home Assistant's
-configuration directory (`<config>/hivemind/<entry_id>/_identity.json`), created on
-first connection. It is kept out of the `custom_components/` package directory so it
-survives upgrades and never needs to write there at runtime.
+configuration directory (`<config>/hivemind/<entry_id>/_identity.json`),
+created on first connection. This directory sits outside the
+`custom_components/` package directory, so the identity survives upgrades and
+the integration never writes there at runtime.
 
-The bus uses a fixed session id (`default`) so the hub does not assign a random
-session per connection. `hivemind-core` only allows the `default` session for
-**admin** clients — which is why the client must be provisioned with `--admin`
-(see [permissions](permissions.md)).
+The bus uses a fixed session id (`default`) so the hub does not assign a
+random session per connection. `hivemind-core` only allows the `default`
+session for **admin** clients. This is why you must provision the client with
+`--admin` (see [permissions](permissions.md)).
+
+---
+[← Setup](setup.md) · [Home](index.md) · [Entities →](entities.md)

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -1,8 +1,8 @@
 # Entities
 
 Which entities appear depends on the configured `device_type` (see
-[configuration](configuration.md)). The table notes the minimum device type that
-exposes each.
+[configuration](configuration.md)). The table notes the minimum device type
+that exposes each entity.
 
 ## Always (all device types)
 
@@ -28,9 +28,9 @@ exposes each.
 | Media player | media_player | OCP-backed playback, volume, transport controls. |
 | Notify | notify | Send text to OVOS to speak (TTS). |
 
-The media player maps Home Assistant `MediaType` values to OVOS OCP media types
-(music, video, movie, episode, TV channel, game, …). With `legacy_audio` enabled it
-drives the legacy Audio Service instead of OCP.
+The media player maps Home Assistant `MediaType` values to OVOS OCP media
+types (music, video, movie, episode, TV channel, game, and others). With
+`legacy_audio` enabled, it drives the legacy Audio Service instead of OCP.
 
 ## `voice_assistant` only
 
@@ -39,5 +39,8 @@ drives the legacy Audio Service instead of OCP.
 | Listener state | sensor | Current listener/recognizer state. |
 | Listening mode | select | Switch the listening mode. |
 
-These cover the microphone / VAD / STT side that only a full voice assistant device
-exposes.
+These entities cover the microphone, VAD, and STT side that only a full voice
+assistant device exposes.
+
+---
+[← Configuration](configuration.md) · [Home](index.md) · [Permissions →](permissions.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 # HiveMind for Home Assistant
 
 A manual-install Home Assistant integration that connects HA to an OpenVoiceOS
-instance over HiveMind and exposes OVOS as Home Assistant entities — media player,
-notify, sensors, switches, buttons, and a listening-mode select.
+instance over HiveMind and exposes OVOS as Home Assistant entities: media
+player, notify, sensors, switches, buttons, and a listening-mode select.
 
 - [Setup](setup.md)
 - [Configuration](configuration.md)
@@ -14,13 +14,13 @@ notify, sensors, switches, buttons, and a listening-mode select.
 Home Assistant acts as a HiveMind **client** connecting to a
 [hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core) hub that runs
 alongside an OVOS instance. Unlike a voice satellite, this integration injects
-low-level OVOS bus messages, so its client key must be admin-privileged with the
-right message-type allowlist (see [permissions](permissions.md)).
+low-level OVOS bus messages. Its client key must therefore be admin-privileged
+with the right message-type allowlist (see [permissions](permissions.md)).
 
 ## How it connects
 
-On setup the integration builds a `HiveMessageBusClient` from the configured host,
-port, access key, and password, and connects in a background task with its own
-retry/backoff. An initial connection failure is logged as a warning rather than
-being fatal, so Home Assistant keeps the device and reconnects when the hub is
-reachable.
+On setup, the integration builds a `HiveMessageBusClient` from the configured
+host, port, access key, and password, and connects in a background task with
+its own retry and backoff. It logs an initial connection failure as a warning
+instead of treating it as fatal, so Home Assistant keeps the device and
+reconnects when the hub becomes reachable.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,21 +1,22 @@
 # Permissions
 
-This integration does more than send voice queries — it injects and controls OVOS
-bus messages directly. The HiveMind client it connects with must therefore have
-**admin** privileges and be allowed the specific message types it uses.
+This integration does more than send voice queries. It injects and controls
+OVOS bus messages directly. The HiveMind client it connects with must
+therefore have **admin** privileges and be allowed the specific message types
+it uses.
 
 ## Why admin
 
-Each entity maps to OVOS bus messages: buttons/switches send control messages
-(stop, reboot, mic mute, volume, sleep), the media player sends OCP transport
-messages, and the sensors subscribe to status messages. A read-only or
-utterance-only client cannot drive these, so the client key must be admin with the
-message types allowlisted.
+Each entity maps to OVOS bus messages: buttons and switches send control
+messages (stop, reboot, mic mute, volume, sleep), the media player sends OCP
+transport messages, and the sensors subscribe to status messages. A read-only
+or utterance-only client cannot drive these, so the client key must be admin
+with the message types allowlisted.
 
-Concretely, the integration pins the `default` OVOS session so the hub does not
-assign a random session per reconnection — and `hivemind-core` only permits the
-`default` session for admin clients. A non-admin client is rejected from that
-session, so provision the client with `--admin`:
+The integration pins the `default` OVOS session so the hub does not assign a
+random session per reconnection, and `hivemind-core` only permits the
+`default` session for admin clients. A non-admin client gets rejected from
+that session, so provision the client with `--admin`:
 
 ```bash
 hivemind-core add-client --admin
@@ -23,16 +24,20 @@ hivemind-core add-client --admin
 
 ## The allowlist
 
-The full, exact list of required message types — grouped by OVOS service
-(ovos-core, ovos-dinkum-listener, ovos-gui, ovos-audio, OCP, the optional Audio
-Service, PHAL and its alsa/system/camera plugins) — is maintained in the
-[README "Permissions Required" section](../README.md#permissions-required).
+The full, exact list of required message types is maintained in the
+[README "Permissions Required" section](../README.md#permissions-required). It
+is grouped by OVOS service: ovos-core, ovos-dinkum-listener, ovos-gui,
+ovos-audio, OCP, the optional Audio Service, and PHAL with its alsa, system,
+and camera plugins.
 
-Provision the HiveMind client on the hub with those message types allowed before
-adding the integration.
+Provision the HiveMind client on the hub with those message types allowed
+before you add the integration.
 
 ## Security
 
 - Only connect trusted Home Assistant instances to your HiveMind hub.
-- The integration directly manipulates OVOS state; scope the client's allowlist to
-  what you actually use.
+- The integration directly manipulates OVOS state. Scope the client's
+  allowlist to what you actually use.
+
+---
+[← Entities](entities.md) · [Home](index.md)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -2,14 +2,15 @@
 
 ## 1. Provision a HiveMind client on the hub
 
-The integration needs an **admin** client key + password on the
+The integration needs an **admin** client key and password on the
 `hivemind-core` hub, with the message-type allowlist from
-[permissions](permissions.md). Add the client on the hub before configuring Home
-Assistant.
+[permissions](permissions.md). Add the client on the hub before you configure
+Home Assistant.
 
 ## 2. Install the integration
 
-Copy the `hivemind` folder into your Home Assistant `custom_components` directory:
+Copy the `hivemind` folder into your Home Assistant `custom_components`
+directory:
 
 ```bash
 mkdir -p /config/custom_components
@@ -20,28 +21,33 @@ Restart Home Assistant.
 
 ## 3. Add the integration
 
-In Home Assistant: **Settings → Devices & Services → Add Integration → HiveMind**.
+In Home Assistant, go to **Settings → Devices & Services → Add Integration →
+HiveMind**.
 
 Fill in the config flow:
 
-- **Device type** — `agent`, `media_player`, or `voice_assistant` (see
+- **Device type**: `agent`, `media_player`, or `voice_assistant` (see
   [configuration](configuration.md)).
-- **Name** — a friendly name for the device.
-- **Host / Port** — the HiveMind hub address (e.g. `ws://192.168.1.10`, port
+- **Name**: a friendly name for the device.
+- **Host / Port**: the HiveMind hub address (e.g. `ws://192.168.1.10`, port
   `5678`).
-- **Access key / Password** — the client credentials you provisioned in step 1.
-- **Site id**, **legacy audio**, **allow self-signed** — optional.
+- **Access key / Password**: the client credentials you provisioned in step 1.
+- **Site id**, **legacy audio**, **allow self-signed**: optional.
 
-The form checks the connection before it is saved: if the hub is unreachable you
-get **"cannot connect"**, and if it rejects the credentials you get **"invalid
-auth"** — so you find out immediately rather than from a silent failure later.
+The form checks the connection before it saves the entry. If the hub is
+unreachable you get **"cannot connect"**. If it rejects the credentials you
+get **"invalid auth"**. Either way, you find out immediately instead of from a
+silent failure later.
 
 ## 4. Verify
 
-Once added, the entities for the chosen device type appear under the new HiveMind
-device (connection sensor, buttons, switches, and — depending on device type — a
-media player, notify, status sensors, and a listening-mode select). See
-[entities](entities.md).
+Once added, the entities for the chosen device type appear under the new
+HiveMind device: a connection sensor, buttons, switches, and, depending on
+device type, a media player, notify, status sensors, and a listening-mode
+select. See [entities](entities.md).
 
-If the connection sensor stays off, check that the hub is reachable, the client key
-is admin-privileged, and the required message types are allowed.
+If the connection sensor stays off, check that the hub is reachable, the
+client key is admin-privileged, and the required message types are allowed.
+
+---
+[Home](index.md) · [Configuration →](configuration.md)


### PR DESCRIPTION
Rewrites the README and docs/*.md pages for clarity, using Simplified Technical English. Merges duplicated installation and permissions content in the README into single sections and adds a Usage section with the existing screenshots. Adds relative-link footer navigation across the docs/ pages.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized and expanded installation, setup, configuration, permissions, security, and troubleshooting guidance.
  * Clarified connection behavior, including retries, backoff, and non-fatal initial failures.
  * Expanded device types, media-player support, voice-assistant entities, and supported media formats.
  * Added guidance for required credentials, admin permissions, authentication errors, and verification steps.
  * Added navigation links and documented licensing and related projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->