### PR TITLE
fix: modernize to hivemind-bus-client 1.x (v3 Noise) and conform to the shipped admin/ACL/session model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,8 @@ integration talks to it via `hivemind_bus_client`. Related repos:
 - **Floor pins only** (`>=X.Y.Za1`), bumped when a feature or fix is actually
   needed — with a one-line comment saying why. No upper caps unless a specific
   released version is genuinely broken (say which and why). The manifest
-  already pins `hivemind_bus_client>=0.4.3` this way.
+  pins `hivemind_bus_client>=1.0.16a1` this way — the v3 Noise line, whose
+  connect/handshake/bus-binding API this integration is written against.
 - **No lockfiles, ever.** Target the latest alphas (`--prerelease=allow`).
 - HA integration requirements live in `custom_components/hivemind/manifest.json`
   (installed by Home Assistant itself on load); test-only deps live in

--- a/custom_components/hivemind/__init__.py
+++ b/custom_components/hivemind/__init__.py
@@ -86,6 +86,18 @@ def _build_bus(identity_file: str, data: dict) -> HiveMessageBusClient:
     )
 
 
+def _connect(bus: HiveMessageBusClient, site_id: str | None = None) -> None:
+    """Open the connection, binding the client's own internal bus.
+
+    ``connect()`` binds a throwaway internal bus by default, so inbound BUS
+    messages land on a bus nobody listens to — the ``on_mycroft`` handlers the
+    entities register live on ``bus.internal_bus``. Passing that same bus is what
+    routes replies (listener state, speak status, service alive/ready) back to
+    the entities, and keeps the pinned "default" session across reconnects.
+    """
+    bus.connect(bus.internal_bus, site_id=site_id)
+
+
 async def get_bus(hass: HomeAssistant, entry: ConfigEntry) -> HiveMessageBusClient:
     """Build the bus client off the event loop."""
     return await hass.async_add_executor_job(
@@ -103,7 +115,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: HiveMindConfigEntry) -> 
 
     async def _connect_later() -> None:
         try:
-            await hass.async_add_executor_job(bus.connect)
+            await hass.async_add_executor_job(_connect, bus)
             _LOGGER.info("Connected to HiveMind bus")
         except Exception as err:  # noqa: BLE001 - connect() retries internally
             _LOGGER.warning(

--- a/custom_components/hivemind/button.py
+++ b/custom_components/hivemind/button.py
@@ -44,7 +44,7 @@ class HiveMindConnectionButton(HiveMindEntity, ButtonEntity):
         self.bus.connected_event.clear()
         self.bus.protocol = None
         self.bus.crypto_key = None
-        self.bus.connect(site_id=self.bus.site_id)
+        self.bus.connect(self.bus.internal_bus, site_id=self.bus.site_id)
 
     @property
     def icon(self) -> str | None:

--- a/custom_components/hivemind/config_flow.py
+++ b/custom_components/hivemind/config_flow.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 
-from . import _build_bus
+from . import _build_bus, _connect
 from .const import DEVICE_TYPES, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,7 +40,7 @@ def _try_handshake(data: dict) -> bool:
     identity_file = os.path.join(tmpdir, "_identity.json")
     bus = _build_bus(identity_file, data)
     try:
-        bus.connect()
+        _connect(bus)
         waiter = getattr(bus, "wait_for_handshake", None)
         if waiter is not None:
             waiter(timeout=10)
@@ -50,8 +50,8 @@ def _try_handshake(data: dict) -> bool:
     finally:
         try:
             bus.close()
-        except Exception:  # noqa: BLE001 - best effort
-            pass
+        except Exception:
+            _LOGGER.debug("Error closing throwaway HiveMind connection", exc_info=True)
 
 
 async def validate_connection(hass: HomeAssistant, data: dict) -> str | None:

--- a/custom_components/hivemind/entity.py
+++ b/custom_components/hivemind/entity.py
@@ -9,7 +9,7 @@ integration stacks duplicate callbacks on the bus.
 """
 
 import logging
-from typing import Callable
+from collections.abc import Callable
 
 from hivemind_bus_client.client import HiveMessageBusClient
 from homeassistant.helpers.device_registry import DeviceInfo

--- a/custom_components/hivemind/manifest.json
+++ b/custom_components/hivemind/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/JarbasHiveMind/hivemind-homeassistant/issues",
   "loggers": ["hivemind_bus_client"],
   "requirements": [
-    "hivemind_bus_client>=0.4.3"
+    "hivemind_bus_client>=1.0.16a1"
   ],
   "version": "0.1.0"
 }

--- a/custom_components/hivemind/media_player.py
+++ b/custom_components/hivemind/media_player.py
@@ -1,27 +1,35 @@
 
 import logging
 from typing import Any
+
 from hivemind_bus_client.client import HiveMessageBusClient
-from hivemind_bus_client.message import HiveMessageType, HiveMessage
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from homeassistant.components import media_source
 from homeassistant.components.media_player import (
+    MediaPlayerEnqueue,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
-    MediaPlayerEnqueue
+)
+from homeassistant.components.media_player.browse_media import (
+    async_process_play_media_url,  #, BrowseMedia, SearchMediaQuery, SearchMedia
 )
 from homeassistant.components.media_player.const import (
-    MediaType, RepeatMode, MediaPlayerState
+    MediaPlayerState,
+    MediaType,
+    RepeatMode,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from ovos_bus_client.message import Message
-from homeassistant.components import media_source
-from homeassistant.components.media_player.browse_media import (
-    async_process_play_media_url #, BrowseMedia, SearchMediaQuery, SearchMedia
+from ovos_utils.ocp import (
+    LoopState,
+    MediaEntry,
+    MediaState,
+    PlaybackType,
+    PlayerState,
+    TrackState,
 )
-
-from ovos_utils.ocp import (MediaType as OCPMediaType, MediaEntry, TrackState,
-                            PlaybackType, PlayerState, MediaState, LoopState)
-
+from ovos_utils.ocp import MediaType as OCPMediaType
 
 from .entity import HiveMindEntity
 
@@ -194,8 +202,8 @@ class HiveMindMediaPlayer(HiveMindEntity, MediaPlayerEntity):
         try:
             _LOGGER.info(f"HiveMind Message: {payload.serialize()}")
             self.bus.emit(payload)
-        except Exception as e:
-            _LOGGER.error(f"Error from HiveMind messagebus: {e}")
+        except Exception:
+            _LOGGER.exception("Error from HiveMind messagebus")
 
     ######
 

--- a/custom_components/hivemind/notify.py
+++ b/custom_components/hivemind/notify.py
@@ -2,10 +2,10 @@
 
 import logging
 
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
 from homeassistant.components.notify import NotifyEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from hivemind_bus_client.message import HiveMessage, HiveMessageType
 from ovos_bus_client import Message
 
 from .entity import HiveMindEntity
@@ -36,7 +36,7 @@ class HiveMindNotifier(HiveMindEntity, NotifyEntity):
             _LOGGER.debug("HiveMind Message: %s", payload.serialize())
             self.bus.emit(payload)
         except Exception:
-            _LOGGER.error("Error from HiveMind messagebus", exc_info=True)
+            _LOGGER.exception("Error from HiveMind messagebus")
 
     def send_message(self, message: str, title: str | None = None) -> None:
         """Send a message."""

--- a/custom_components/hivemind/select.py
+++ b/custom_components/hivemind/select.py
@@ -1,7 +1,6 @@
 """HiveMind select: listening mode (via ovos-dinkum-listener)."""
 
 import logging
-from typing import List
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
@@ -46,7 +45,7 @@ class HiveMindListeningMode(HiveMindEntity, SelectEntity):
         return self._mode
 
     @property
-    def options(self) -> List[str]:
+    def options(self) -> list[str]:
         return ["wakeword", "continuous", "hybrid"]
 
     async def async_select_option(self, option: str) -> None:

--- a/custom_components/hivemind/sensor.py
+++ b/custom_components/hivemind/sensor.py
@@ -1,7 +1,6 @@
 """HiveMind sensor: listener state (via ovos-dinkum-listener)."""
 
 import logging
-from typing import List
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -36,7 +35,7 @@ class HiveMindListenerStateSensor(HiveMindEntity, SensorEntity):
         return self._uid("listen-state")
 
     @property
-    def options(self) -> List[str]:
+    def options(self) -> list[str]:
         return [
             "wakeword", "continuous", "recording", "sleeping", "wake_up",
             "confirmation", "before_cmd", "in_cmd", "after_cmd",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,7 @@
 # Tier 1 test dependencies (no network): the HA test harness plus the
 # integration's own runtime requirements so the component imports.
 pytest-homeassistant-custom-component
-hivemind_bus_client>=0.4.3
+hivemind_bus_client>=1.0.16a1
 ovos-bus-client
 ovos-utils
 json_database

--- a/tests/e2e/test_ha_integration_e2e.py
+++ b/tests/e2e/test_ha_integration_e2e.py
@@ -17,11 +17,12 @@ hub's deny-by-default ACL, and exchanges real messages.
 import time
 from urllib.parse import urlparse
 
-import custom_components.hivemind  # noqa: F401 - ensure HA can discover the integration
 import pytest
-from homeassistant.setup import async_setup_component
 from hivescope.topology import TopologyBuilder
+from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+import custom_components.hivemind  # noqa: F401 - ensure HA can discover the integration
 
 SAT_KEY = "ha-key"
 SAT_PASSWORD = "ha-password"

--- a/tests/fake_bus.py
+++ b/tests/fake_bus.py
@@ -22,6 +22,8 @@ class FakeHiveBus:
             self.connected_event.set()
         self._host = "ws://testhub"
         self.site_id = "test"
+        # the real client exposes the pinned internal bus that connect() binds
+        self.internal_bus = self
         self.protocol = object()
         self.crypto_key = b"k"
         self.handlers: dict[str, list] = {}

--- a/tests/test_bus_wiring.py
+++ b/tests/test_bus_wiring.py
@@ -1,0 +1,44 @@
+"""The connection must bind the client's own internal bus.
+
+Entities register their handlers with ``on_mycroft``, which lands them on
+``bus.internal_bus``. If ``connect()`` binds a different (default) internal bus,
+inbound BUS replies are dispatched to a bus nobody listens to and every
+status entity stays blind. This exercises the real ``hivemind_bus_client``
+rather than the test double, since the defect lives in how the two buses are
+wired together.
+"""
+
+from hivemind_bus_client.client import HiveMessageBusClient
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from ovos_bus_client.message import Message
+
+from custom_components.hivemind import _build_bus, _connect
+
+CONFIG = {
+    "access_key": "0123456789abcdef",
+    "password": "pw",
+    "host": "localhost",
+    "port": 5678,
+    "site_id": "test",
+    "name": "Home Assistant",
+}
+
+
+def test_connect_routes_inbound_messages_to_registered_handlers(monkeypatch, tmp_path):
+    # keep connect() off the network: no worker thread, handshake "succeeds"
+    monkeypatch.setattr(HiveMessageBusClient, "run_in_thread", lambda self: None)
+    monkeypatch.setattr(
+        HiveMessageBusClient, "wait_for_handshake", lambda self, *a, **k: True
+    )
+
+    bus = _build_bus(str(tmp_path / "_identity.json"), CONFIG)
+    received = []
+    bus.on_mycroft("recognizer_loop:state", received.append)
+
+    _connect(bus)
+
+    bus.protocol.handle_bus(
+        HiveMessage(HiveMessageType.BUS, Message("recognizer_loop:state", {"mode": 1}))
+    )
+
+    assert received, "on_mycroft handler never saw the injected bus message"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,10 +2,11 @@
 
 from unittest.mock import patch
 
-import custom_components.hivemind as hivemind
-import custom_components.hivemind.config_flow as config_flow
 from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components import hivemind
+from custom_components.hivemind import config_flow
 
 from .fake_bus import FakeHiveBus
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -3,9 +3,10 @@
 import asyncio
 from unittest.mock import patch
 
-import custom_components.hivemind as hivemind
-from custom_components.hivemind.button import HiveMindConnectionButton
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components import hivemind
+from custom_components.hivemind.button import HiveMindConnectionButton
 
 from .fake_bus import FakeHiveBus
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,10 +2,11 @@
 
 from unittest.mock import patch
 
-import custom_components.hivemind as hivemind
 import pytest
 from homeassistant.config_entries import ConfigEntryState
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components import hivemind
 
 from .fake_bus import FakeHiveBus
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2,9 +2,10 @@
 
 from unittest.mock import patch
 
-import custom_components.hivemind as hivemind
 from homeassistant.config_entries import ConfigEntryState
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components import hivemind
 
 from .fake_bus import FakeHiveBus
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus (via Claude Code) — NOT human-reviewed. Verify before acting.

The manifest floor for `hivemind_bus_client` sat at `>=0.4.3`, a version from before the v3 Noise rewrite. Home Assistant installs a component's manifest requirements when it loads the integration, so that floor allowed a v0.4.x client to ship against a hub that now speaks the 1.x connect/handshake/bus-binding protocol. The floor is raised to `>=1.0.16a1` in `manifest.json` (what actually ships to users) and in `requirements_test.txt`, so the version under test matches the API the code is written against.

Raising the floor exposes a real wiring bug. In 1.x, `connect()` binds a throwaway internal bus by default, while the entities register their reply handlers with `on_mycroft`, which lands them on the client's own `internal_bus`. Those are two different bus objects, so every inbound BUS reply — listener state, speak status, per-service alive/ready — was dispatched to a bus nobody listens to, and the status entities stayed permanently blind. `connect()` is now called with `bus.internal_bus` at all three call sites (initial setup, config-flow validation, and the reconnect button), which also keeps the pinned `default` session stable across reconnects instead of letting each reconnect fall back to a fresh bus.

On the conformance side the shipped model already lines up. The README's permissions section correctly tells the operator to give the HA client admin privileges and to allow-list the exact low-level message types it injects, and it does not claim admin bypasses the allowlist — admins still follow deny-by-default ACLs, which is what the hub enforces. The config flow already validates the connection before saving and surfaces `cannot_connect` / `invalid_auth`, so a bad key or unreachable hub fails fast; with the 1008 auth-close on the hub, a rejected handshake now ends the bounded `wait_for_handshake` rather than retrying forever. No code change was needed for those.

The regression test drives the real `hivemind_bus_client` rather than the test double, because the defect lives in how the two internal buses are wired: it registers an `on_mycroft` handler, connects (with the worker thread and handshake stubbed off the network), and injects a BUS message through the protocol. With the old `bus.connect()` the handler never fires; with the fix it receives the message. Reverting only the binding line flips that assertion. The full tier-1 suite is 18 passed.

What still needs a live HA + hub to validate: an end-to-end round trip against a real `hivemind-core` (the `tests/e2e` tier via `hivescope`) confirming the v3 Noise handshake negotiates, that the allow-listed message types actually reach OVOS and their replies flow back to the HA entities, that a wrong key produces `invalid_auth` and a 1008 close does not loop, and that the reconnect button recovers the pinned session.
