### PR TITLE
fix: bound handshake retries, use persistent identity for validation, dedupe inbound handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,25 @@ under [Permissions Required](#permissions-required).
 
 2. Restart Home Assistant.
 
+### Prerelease requirement
+
+This integration depends on prerelease packages. Its dependency closure pulls in
+`poorman-handshake`, whose required version is a prerelease, so the integration
+must be installed in an environment where prerelease resolution is enabled. A
+stock Home Assistant add flow, or a plain `pip install` that does not enable
+prereleases, fails to resolve the dependencies and reports `RequirementsNotFound`.
+
+Install into an environment that allows prereleases, for example:
+
+```bash
+uv pip install --prerelease=allow hivemind_bus_client
+# or
+pip install --pre hivemind_bus_client
+```
+
+This requirement stands until the HiveMind stack ships stable releases, at which
+point stock resolution succeeds without the prerelease flag.
+
 ### Add the integration
 
 Go to **Settings → Devices & Services → Add Integration → HiveMind**. The

--- a/custom_components/hivemind/__init__.py
+++ b/custom_components/hivemind/__init__.py
@@ -1,5 +1,6 @@
 """The HiveMind integration."""
 
+import hashlib
 import logging
 import os
 from dataclasses import dataclass
@@ -36,14 +37,22 @@ def _platforms(device_type: str) -> list[str]:
     return domains
 
 
-def _identity_path(hass: HomeAssistant, entry: ConfigEntry) -> str:
-    """Per-entry identity file, stored under Home Assistant's config dir.
+def _identity_path(hass: HomeAssistant, access_key: str) -> str:
+    """Persistent identity file for a given access key.
 
     The node identity (and the RSA key written alongside it) must live in a
     writable, persistent location that is *not* the integration's install
     directory — that directory can be read-only and is wiped on upgrade.
+
+    The path is keyed by the access key (not the config entry id) so the
+    config-flow validation and the runtime connection share one identity, and
+    therefore one Noise static key. A hub that pins the first static key it sees
+    per access key would otherwise pin whatever key validation used and lock the
+    real connection out. The access key is hashed only to keep it filesystem
+    safe; it is not a secret store.
     """
-    return hass.config.path(DOMAIN, entry.entry_id, "_identity.json")
+    slug = hashlib.sha256(access_key.encode()).hexdigest()[:16]
+    return hass.config.path(DOMAIN, slug, "_identity.json")
 
 
 def _build_bus(identity_file: str, data: dict) -> HiveMessageBusClient:
@@ -86,7 +95,11 @@ def _build_bus(identity_file: str, data: dict) -> HiveMessageBusClient:
     )
 
 
-def _connect(bus: HiveMessageBusClient, site_id: str | None = None) -> None:
+def _connect(
+    bus: HiveMessageBusClient,
+    site_id: str | None = None,
+    handshake_max_retries: int | None = None,
+) -> None:
     """Open the connection, binding the client's own internal bus.
 
     ``connect()`` binds a throwaway internal bus by default, so inbound BUS
@@ -94,14 +107,24 @@ def _connect(bus: HiveMessageBusClient, site_id: str | None = None) -> None:
     entities register live on ``bus.internal_bus``. Passing that same bus is what
     routes replies (listener state, speak status, service alive/ready) back to
     the entities, and keeps the pinned "default" session across reconnects.
+
+    ``handshake_max_retries`` bounds the handshake wait ``connect()`` performs
+    internally. Runtime setup leaves it ``None`` (retry forever); the config
+    flow passes a small bound so a wrong password — which the hub answers by
+    closing the socket cleanly (v3 Noise) rather than tripping ``_auth_rejected``
+    — fails fast instead of reconnecting forever.
     """
-    bus.connect(bus.internal_bus, site_id=site_id)
+    bus.connect(
+        bus.internal_bus,
+        site_id=site_id,
+        handshake_max_retries=handshake_max_retries,
+    )
 
 
 async def get_bus(hass: HomeAssistant, entry: ConfigEntry) -> HiveMessageBusClient:
     """Build the bus client off the event loop."""
     return await hass.async_add_executor_job(
-        _build_bus, _identity_path(hass, entry), dict(entry.data)
+        _build_bus, _identity_path(hass, entry.data["access_key"]), dict(entry.data)
     )
 
 

--- a/custom_components/hivemind/config_flow.py
+++ b/custom_components/hivemind/config_flow.py
@@ -1,15 +1,13 @@
 """Config flow for the HiveMind integration."""
 
 import logging
-import os
-import tempfile
 from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 
-from . import _build_bus, _connect
+from . import _build_bus, _connect, _identity_path
 from .const import DEVICE_TYPES, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,36 +26,42 @@ HIVEMIND_SCHEMA = {
 }
 
 
-def _try_handshake(data: dict) -> bool:
-    """Open a throwaway connection to the hub and report whether it handshakes.
+def _try_handshake(data: dict, identity_file: str) -> bool:
+    """Open a validation connection to the hub and report whether it handshakes.
 
-    Runs in an executor (socket + file I/O). Uses a temporary identity so it
-    never touches the real per-entry identity. Returns True on a completed
-    handshake, False if the hub answered but never completed it (typically a
-    bad access key / password).
+    Runs in an executor (socket + file I/O). It uses the *same* persistent
+    identity the entry will use at runtime, so the Noise static key validated
+    here is the one that actually runs — a throwaway key would be pinned by the
+    hub and lock the real connection out. Returns True on a completed handshake,
+    False if the hub answered but the handshake never completed within a bounded
+    number of retries (typically a wrong access key / password).
+
+    The handshake wait is bounded (``handshake_max_retries=1``): a wrong
+    password on v3 Noise makes the hub close the socket cleanly (ws 1000)
+    without ever tripping ``_auth_rejected``, so an unbounded wait would
+    reconnect forever and hang the config flow. The client is always closed in
+    ``finally`` so no reconnect thread outlives the aborted validation.
     """
-    tmpdir = tempfile.mkdtemp(prefix="hivemind-validate-")
-    identity_file = os.path.join(tmpdir, "_identity.json")
     bus = _build_bus(identity_file, data)
     try:
-        _connect(bus)
-        waiter = getattr(bus, "wait_for_handshake", None)
-        if waiter is not None:
-            waiter(timeout=10)
-        else:  # pragma: no cover - very old client
-            bus.handshake_event.wait(timeout=10)
+        try:
+            _connect(bus, handshake_max_retries=1)
+        except (RuntimeError, ConnectionRefusedError):
+            # hub reachable but handshake never completed: bad key / password
+            return False
         return bool(bus.handshake_event.is_set())
     finally:
         try:
             bus.close()
         except Exception:
-            _LOGGER.debug("Error closing throwaway HiveMind connection", exc_info=True)
+            _LOGGER.debug("Error closing HiveMind validation connection", exc_info=True)
 
 
 async def validate_connection(hass: HomeAssistant, data: dict) -> str | None:
     """Validate the hub connection. Returns an error key, or None on success."""
+    identity_file = _identity_path(hass, data["access_key"])
     try:
-        ok = await hass.async_add_executor_job(_try_handshake, data)
+        ok = await hass.async_add_executor_job(_try_handshake, data, identity_file)
     except Exception as err:  # noqa: BLE001 - surface as cannot_connect
         _LOGGER.warning("HiveMind connection validation failed: %s", err)
         return "cannot_connect"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -24,7 +24,7 @@ USER_INPUT = {
 
 
 async def _submit(hass, *, handshake_ok=True, raises=False):
-    def _fake_validate(data):
+    def _fake_validate(data, identity_file):
         if raises:
             raise ConnectionError("boom")
         return handshake_ok

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,104 @@
+"""Config-flow validation defects surfaced by a live Home Assistant e2e run.
+
+Covers three things the throwaway-connection validation used to get wrong:
+
+* a wrong password must fail fast (bounded handshake retries) instead of
+  reconnecting forever and hanging the flow, and the client must be torn down;
+* validation must reuse the persistent per-access-key identity, so the Noise
+  static key it pins is the one the runtime connection uses;
+* a single ``on_mycroft`` registration must dispatch each inbound reply once.
+"""
+
+from unittest.mock import patch
+
+from hivemind_bus_client.client import HiveMessageBusClient
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from ovos_bus_client.message import Message
+
+from custom_components import hivemind
+from custom_components.hivemind import _build_bus, _connect, _identity_path, config_flow
+
+DATA = {
+    "device_type": "voice_assistant",
+    "name": "Living Room",
+    "host": "ws://127.0.0.1",
+    "access_key": "0123456789abcdef",
+    "password": "wrong-password",
+    "port": 5678,
+    "legacy_audio": False,
+    "site_id": "test",
+    "allow_self_signed": False,
+}
+
+
+def test_wrong_password_bounds_handshake_and_closes(hass):
+    """A never-completing handshake returns False promptly and closes the bus.
+
+    On v3 Noise a wrong password makes the hub close the socket cleanly, so the
+    client never trips ``_auth_rejected`` and an unbounded wait would reconnect
+    forever. ``_try_handshake`` must pass a bounded ``max_retries`` through
+    ``connect()`` and tear the client down.
+    """
+    seen = {}
+
+    def _fake_wait(self, timeout=5, max_retries=None):
+        seen["max_retries"] = max_retries
+        # simulate the bounded loop giving up (never handshakes)
+        raise RuntimeError("timed out waiting for handshake")
+
+    with (
+        patch.object(HiveMessageBusClient, "run_in_thread", lambda self: None),
+        patch.object(HiveMessageBusClient, "wait_for_handshake", _fake_wait),
+        patch.object(HiveMessageBusClient, "close") as close,
+    ):
+        path = _identity_path(hass, DATA["access_key"])
+        ok = config_flow._try_handshake(DATA, path)
+
+    assert ok is False
+    assert seen["max_retries"] == 1, "handshake wait must be bounded, not infinite"
+    assert close.called, "the validation client must be closed on failure"
+
+
+async def test_validation_uses_persistent_identity_not_throwaway(hass):
+    """Validation must build its client with the entry's persistent identity."""
+    captured = {}
+
+    def _spy_build(identity_file, data):
+        captured["identity_file"] = identity_file
+        return _build_bus(identity_file, data)
+
+    with (
+        patch.object(hivemind, "_build_bus", side_effect=_spy_build),
+        patch.object(config_flow, "_build_bus", side_effect=_spy_build),
+        patch.object(HiveMessageBusClient, "run_in_thread", lambda self: None),
+        patch.object(
+            HiveMessageBusClient, "wait_for_handshake", lambda self, *a, **k: True
+        ),
+        patch.object(HiveMessageBusClient, "close", lambda self: None),
+    ):
+        await config_flow.validate_connection(hass, DATA)
+
+    # the identity used to validate is the persistent per-access-key path the
+    # runtime connection will reuse, not a throwaway tempdir
+    expected = _identity_path(hass, DATA["access_key"])
+    assert captured["identity_file"] == expected
+
+
+def test_single_registration_dispatches_inbound_once(monkeypatch, tmp_path):
+    """One ``on_mycroft`` registration handles each inbound BUS reply exactly once."""
+    monkeypatch.setattr(HiveMessageBusClient, "run_in_thread", lambda self: None)
+    monkeypatch.setattr(
+        HiveMessageBusClient, "wait_for_handshake", lambda self, *a, **k: True
+    )
+
+    bus = _build_bus(str(tmp_path / "_identity.json"), DATA)
+    calls = []
+    bus.on_mycroft("recognizer_loop:state", calls.append)
+
+    _connect(bus)
+
+    bus.protocol.handle_bus(
+        HiveMessage(HiveMessageType.BUS, Message("recognizer_loop:state", {"mode": 1}))
+    )
+
+    assert len(calls) == 1, f"inbound reply dispatched {len(calls)} times, expected 1"


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus (via Claude Code) — NOT human-reviewed. Verify before acting.

A live Home Assistant end-to-end run against a real hivemind-core hub surfaced two config-flow defects and confirmed a third suspected path is actually safe. All three are addressed or dispositioned here in one commit, with fail-before regression tests.

Wrong password used to hang the config flow forever. `_try_handshake` opened the validation connection through `_connect`, whose underlying `connect()` waits for the handshake with `max_retries=None`, meaning it retries forever. On v3 Noise a wrong password makes the hub close the socket cleanly (ws 1000) without ever tripping `_auth_rejected`, so the client kept reconnecting every few seconds and the flow never returned (a >120s hang). `_connect` now forwards a `handshake_max_retries` bound and the config flow passes `1`, so a never-completing handshake returns `invalid_auth` within seconds. The validation client is closed in a `finally` block so no reconnect thread outlives the aborted flow.

Validation also poisoned the Noise pin. `_try_handshake` built a throwaway identity in a tempdir, whose Noise static key differed from the persistent per-entry identity used at runtime. A hub that pins the first static key it sees per access key pinned the throwaway key, and the real runtime connection could then never match, leaving every entity `unavailable` until an operator ran `hivemind-core reset-noise-pin`. The identity file is now keyed by access key and shared between validation and runtime, so the key that is validated is the key that runs.

Duplicate inbound delivery was investigated and is not caused by the integration. With a single `on_mycroft` registration, the integration's `_build_bus`/`_connect` wiring dispatches each inbound BUS reply exactly once, because it binds the client's own `internal_bus` (the same bus the entity handlers register on) for both client construction and `connect()`, and re-binding on reconnect does not stack the entity handler. If a minimal client sees double delivery, that is a hivemind-bus-client behaviour, not an integration bug. A regression test locks the single-dispatch behaviour in.

Fail-before was verified by patch-revert: the bounded-retry and persistent-identity tests fail against the unfixed source (infinite wait; tempdir identity path) and pass after the fix; the single-dispatch test passes both before and after, confirming the integration was never the double-delivery source. The full tier-1 suite is 21 passed, and `ruff check custom_components tests` is clean.

The README gains a short prerelease-requirement note. Per the maintainer decision to keep the stack on alphas for now, the integration's dependency closure includes prereleases (`hivemind_bus_client` pulls `poorman-handshake` at a prerelease version), so it must be installed with prereleases enabled (`uv pip install --prerelease=allow ...` / `pip install --pre ...`). A stock Home Assistant add flow that does not enable prereleases fails to resolve with `RequirementsNotFound`. This is a separate stack-wide release-discipline matter; the manifest floor and pins are intentionally left unchanged here.
