### PR TITLE
fix: install hivescope from PyPI, not a deleted git branch

### DIFF
--- a/requirements_test_e2e.txt
+++ b/requirements_test_e2e.txt
@@ -1,5 +1,7 @@
 # Tier 2 (real-hub) e2e dependencies. Install with --pre: the hivemind-core
-# stack hivescope pulls in is still prerelease (2.x migration). hivescope is
-# pinned to the loopback-whitelist branch until that fix is released.
+# stack that hivescope pulls in is still prerelease (2.x migration).
 -r requirements_test.txt
-hivescope @ git+https://github.com/JarbasHiveMind/hivescope.git@fix/loopback-whitelist-only-connection
+hivescope>=0.8.1a1
+# hard per-test timeout so a stuck real-hub handshake fails fast instead of
+# hanging CI (the @pytest.mark.timeout on the e2e test needs this plugin)
+pytest-timeout

--- a/tests/e2e/test_ha_integration_e2e.py
+++ b/tests/e2e/test_ha_integration_e2e.py
@@ -14,6 +14,7 @@ hub's deny-by-default ACL, and exchanges real messages.
     -> hub admits it and injects it onto the agent bus
 """
 
+import threading
 import time
 from urllib.parse import urlparse
 
@@ -25,7 +26,10 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 import custom_components.hivemind  # noqa: F401 - ensure HA can discover the integration
 
 SAT_KEY = "ha-key"
-SAT_PASSWORD = "ha-password"
+# poorman_handshake enforces a 40-bit password-strength floor; a weak password
+# makes the hub's handshake crash on every connect and the client reconnect
+# forever, so this must be a high-entropy passphrase like a real deployment uses.
+SAT_PASSWORD = "SAT-e2e-Xq7v-Long-Passphrase-2026-hivemind"
 # the message types the integration actually emits that we assert on
 ALLOWED = [
     "mycroft.stop",
@@ -60,6 +64,7 @@ async def _wait_handshake(hass, bus, timeout=15):
         await hass.async_add_executor_job(time.sleep, 0.1)
 
 
+@pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_integration_connects_to_real_hub_and_speaks(hass, socket_enabled):
     # register core services (homeassistant.update_entity, button.press, ...)
@@ -121,3 +126,17 @@ async def test_integration_connects_to_real_hub_and_speaks(hass, socket_enabled)
         await hass.config_entries.async_unload(entry.entry_id)
         await hass.async_block_till_done()
         builder.stop_all()
+        # HiveMessageBusClient.close() (called by async_unload_entry) signals its
+        # reconnect worker to stop but does not join it, and the client exposes
+        # no public per-instance handle to that daemon thread, so it can briefly
+        # outlive unload and trip Home Assistant's strict lingering-thread check.
+        # Wait it out here and assert it really died, rather than leaking it.
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            workers = [t for t in threading.enumerate() if "_run_worker" in t.name]
+            if not workers:
+                break
+            await hass.async_add_executor_job(workers[0].join, 1)
+        assert not [
+            t for t in threading.enumerate() if "_run_worker" in t.name
+        ], "hivemind bus client leaked its reconnect worker thread after unload"


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 4.8 (claude-opus-4-8) via Claude Code — NOT human-reviewed. Verify before acting.

## The dependency repoint

`requirements_test_e2e.txt` pinned hivescope to the git branch `fix/loopback-whitelist-only-connection`. That branch merged into hivescope `dev` and was deleted, so every e2e run failed at install (`pathspec ... did not match`), which broke the `e2e` job on `dev` and on all open PRs and violated the "never install from git — publish an alpha and depend on that" rule. This now depends on `hivescope>=0.8.1a1` from PyPI; the whitelist-only loopback admission the branch added ships in that release (`hivescope/plugins/loopback.py`).

## The e2e hang the repoint exposed

With the install finally succeeding, `tests/e2e/test_ha_integration_e2e.py` ran for the first time — and hung indefinitely (30+ minutes in CI before it was cancelled). Root cause: the released `poorman_handshake` enforces a 40-bit password-strength floor, and the test registered its satellite with the ~17-bit password `"ha-password"`. The loopback hub's `PasswordHandShake` raised `WeakPasswordError` on every connection, so the HiveMind bus client reconnected forever and the Home Assistant config-entry setup never settled. This is a test defect, not a product bug: a real deployment cannot use a password that weak either. The fix uses a high-entropy passphrase, and the test then completes a genuine encrypted round trip in a couple of seconds.

## The lingering-thread teardown failure

Once the test passed its logic it still failed the job with exit 1 on Home Assistant's strict lingering-thread cleanup check: the HiveMind bus client's reconnect worker (`Thread-N (_run_worker)`) was still alive at teardown. `async_unload_entry` already calls `HiveMessageBusClient.close()`, which is the correct shutdown call — but `close()` only signals the worker to stop, it does not join the daemon thread, and the client exposes no public per-instance handle to that thread (`connect()` discards the `Thread` returned by `run_in_thread()`, and a name-based scan is unsafe for the integration because it would join another config entry's worker). So the thread briefly outlives unload. This is a hivemind_bus_client limitation worth fixing upstream (`close()` should join its worker, or expose it). Meanwhile the e2e test now bounded-joins the worker after unload and asserts it is gone, so the test cleans up after itself instead of leaking, and the check is enforced rather than masked.

## The guard so this can never hang CI again

The e2e requirements now include `pytest-timeout`, and the e2e test carries `@pytest.mark.timeout(120)`. Any future stuck handshake becomes a fast, legible failure instead of an unbounded hang. Verified by reverting to the weak password: the same condition that previously hung forever now fails within the timeout.

## Test results

The real-hub e2e test passes (1 passed in ~3s) with no lingering-thread error; the worker thread is observably alive at unload and the bounded join clears it. The tier-1 suite is unchanged (18 passed). Ruff is clean.
