### PR TITLE
fix: preserve form input on error and clarify config-flow copy and install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ under [Permissions Required](#permissions-required).
 - An admin-privileged HiveMind client key and password registered on the hub
   for Home Assistant (see [Permissions Required](#permissions-required)).
 - Home Assistant with access to its `config/custom_components/` directory.
-- The integration declares the runtime requirement `hivemind_bus_client>=0.4.3`,
-  which Home Assistant installs on first load.
+- The integration declares the runtime requirement
+  `hivemind_bus_client>=1.0.16a1`, a prerelease — see
+  [Prerelease requirement](#prerelease-requirement) below.
 
 ## Installation
 
@@ -61,10 +62,14 @@ prereleases, fails to resolve the dependencies and reports `RequirementsNotFound
 Install into an environment that allows prereleases, for example:
 
 ```bash
-uv pip install --prerelease=allow hivemind_bus_client
+uv pip install --prerelease=allow "hivemind_bus_client>=1.0.16a1"
 # or
-pip install --pre hivemind_bus_client
+pip install --pre "hivemind_bus_client>=1.0.16a1"
 ```
+
+In a Home Assistant container, run the equivalent `pip install --pre` command
+inside the container (or its virtual environment) before you add the
+integration.
 
 This requirement stands until the HiveMind stack ships stable releases, at which
 point stock resolution succeeds without the prerelease flag.
@@ -84,12 +89,12 @@ The config flow asks for these fields when you add the integration:
 | --- | --- | --- |
 | `device_type` | `voice_assistant` | Which OVOS capabilities to expose (see below). |
 | `name` | n/a | Friendly name for the device in Home Assistant. |
-| `host` | n/a | HiveMind hub host (e.g. `ws://192.168.1.10`). |
+| `host` | n/a | HiveMind hub address — a bare hostname/IP (e.g. `192.168.1.10`) or a `ws://`/`wss://` URL to force the scheme. |
+| `port` | `5678` | HiveMind WebSocket port; a separate field from `host`. |
 | `access_key` | n/a | HiveMind client access key. |
 | `password` | n/a | HiveMind client password. |
-| `port` | `5678` | HiveMind WebSocket port. |
 | `legacy_audio` | `false` | Use the legacy Audio Service instead of OCP. |
-| `site_id` | `unknown` | OVOS site id. |
+| `site_id` | empty | Optional OVOS site id; leave blank if you have one hub. |
 | `allow_self_signed` | `false` | Accept a self-signed TLS certificate. |
 
 ### Device types

--- a/custom_components/hivemind/config_flow.py
+++ b/custom_components/hivemind/config_flow.py
@@ -17,11 +17,11 @@ HIVEMIND_SCHEMA = {
     vol.Required("device_type", default="voice_assistant"): vol.In(DEVICE_TYPES),
     vol.Required("name"): str,
     vol.Required("host"): str,
+    vol.Required("port", default=5678): int,
     vol.Required("access_key"): str,
     vol.Required("password"): str,
-    vol.Required("port", default=5678): int,
     vol.Required("legacy_audio", default=False): bool,
-    vol.Optional("site_id", default="unknown"): str,
+    vol.Optional("site_id"): str,
     vol.Required("allow_self_signed", default=False): bool,
 }
 
@@ -89,8 +89,12 @@ class HiveMindConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
             errors["base"] = error
 
+        suggested_values = {k: v for k, v in (user_input or {}).items() if k != "password"}
+        data_schema = self.add_suggested_values_to_schema(
+            vol.Schema(HIVEMIND_SCHEMA), suggested_values
+        )
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(HIVEMIND_SCHEMA),
+            data_schema=data_schema,
             errors=errors,
         )

--- a/custom_components/hivemind/const.py
+++ b/custom_components/hivemind/const.py
@@ -4,7 +4,7 @@ DOMAIN = "hivemind"
 USER_AGENT = "HomeAssistant"
 
 DEVICE_TYPES = {
-    "agent": "Agent – Text input/output only (OpenVoiceOS, LLM ...)",
-    "media_player": "Media Player – Audio output only (playback, volume, TTS ...)",
-    "voice_assistant": "Voice Assistant – Agent + Audio output + Audio input (mic, VAD, wake word, STT ...)"
+    "agent": "Agent — text only (OpenVoiceOS, LLM ...)",
+    "media_player": "Media Player — audio out only (playback, volume, TTS ...)",
+    "voice_assistant": "Voice Assistant — full two-way voice (mic in, speaks back) (Agent + Audio output + Audio input: mic, VAD, wake word, STT ...)"
 }

--- a/custom_components/hivemind/strings.json
+++ b/custom_components/hivemind/strings.json
@@ -8,18 +8,25 @@
           "device_type": "Device type",
           "name": "Name",
           "host": "Host",
+          "port": "Port",
           "access_key": "Access key",
           "password": "Password",
-          "port": "Port",
           "legacy_audio": "Use the legacy audio service instead of OCP",
           "site_id": "Site ID",
           "allow_self_signed": "Allow self-signed certificates"
+        },
+        "data_description": {
+          "host": "Hub address — hostname or IP, e.g. 192.168.1.10; ws:// or wss:// optional",
+          "port": "Must match your hub's listener; default 5678",
+          "site_id": "Optional grouping label; leave as-is if you have one hub",
+          "name": "Friendly name shown in Home Assistant, e.g. 'Living Room HiveMind'",
+          "legacy_audio": "OCP is the OVOS media-playback system; enable this to use the older audio service instead"
         }
       }
     },
     "error": {
       "cannot_connect": "Could not reach the hub. Check the host, port, and that hivemind-core is running.",
-      "invalid_auth": "The hub rejected these credentials. Check the access key and password from `hivemind-core list-clients`."
+      "invalid_auth": "The hub answered but rejected the connection. Check the access key and password (from hivemind-core list-clients) — and confirm the port matches your hub's listener."
     },
     "abort": {
       "already_configured": "This hub is already configured."

--- a/custom_components/hivemind/translations/en.json
+++ b/custom_components/hivemind/translations/en.json
@@ -8,18 +8,25 @@
           "device_type": "Device type",
           "name": "Name",
           "host": "Host",
+          "port": "Port",
           "access_key": "Access key",
           "password": "Password",
-          "port": "Port",
           "legacy_audio": "Use the legacy audio service instead of OCP",
           "site_id": "Site ID",
           "allow_self_signed": "Allow self-signed certificates"
+        },
+        "data_description": {
+          "host": "Hub address — hostname or IP, e.g. 192.168.1.10; ws:// or wss:// optional",
+          "port": "Must match your hub's listener; default 5678",
+          "site_id": "Optional grouping label; leave as-is if you have one hub",
+          "name": "Friendly name shown in Home Assistant, e.g. 'Living Room HiveMind'",
+          "legacy_audio": "OCP is the OVOS media-playback system; enable this to use the older audio service instead"
         }
       }
     },
     "error": {
       "cannot_connect": "Could not reach the hub. Check the host, port, and that hivemind-core is running.",
-      "invalid_auth": "The hub rejected these credentials. Check the access key and password from `hivemind-core list-clients`."
+      "invalid_auth": "The hub answered but rejected the connection. Check the access key and password (from hivemind-core list-clients) — and confirm the port matches your hub's listener."
     },
     "abort": {
       "already_configured": "This hub is already configured."

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -19,6 +19,23 @@ cp -r custom_components/hivemind /config/custom_components/
 
 Restart Home Assistant.
 
+### Prerelease requirement
+
+This integration depends on a prerelease of `hivemind_bus_client`. Stock Home
+Assistant does not install prerelease packages, so a plain add of the
+integration fails with `RequirementsNotFound`. Before you add the integration,
+pre-install the dependency into the Home Assistant environment with prerelease
+resolution enabled, for example:
+
+```bash
+pip install --pre "hivemind_bus_client>=1.0.16a1"
+```
+
+In a Home Assistant container, run the equivalent `pip install --pre` command
+inside the container (or its virtual environment) before you restart Home
+Assistant and add the integration. This requirement stands until the
+HiveMind stack ships a stable release.
+
 ## 3. Add the integration
 
 In Home Assistant, go to **Settings → Devices & Services → Add Integration →
@@ -29,8 +46,9 @@ Fill in the config flow:
 - **Device type**: `agent`, `media_player`, or `voice_assistant` (see
   [configuration](configuration.md)).
 - **Name**: a friendly name for the device.
-- **Host / Port**: the HiveMind hub address (e.g. `ws://192.168.1.10`, port
-  `5678`).
+- **Host**: the HiveMind hub address — a bare hostname or IP (e.g.
+  `192.168.1.10`) or a `ws://`/`wss://` URL if you need to force the scheme
+  (`wss://` for TLS). **Port** is a separate field, default `5678`.
 - **Access key / Password**: the client credentials you provisioned in step 1.
 - **Site id**, **legacy audio**, **allow self-signed**: optional.
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -63,6 +63,21 @@ async def test_unreachable_hub_shows_cannot_connect(hass):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
+async def test_error_preserves_entered_values_except_password(hass):
+    result = await _submit(hass, handshake_ok=False)
+    assert result["type"] is FlowResultType.FORM
+
+    schema = result["data_schema"].schema
+    suggested = {
+        key: key.description["suggested_value"]
+        for key in schema
+        if hasattr(key, "description") and key.description
+    }
+    for field in ("device_type", "name", "host", "access_key", "port", "site_id"):
+        assert suggested.get(field) == USER_INPUT[field]
+    assert "password" not in suggested
+
+
 async def test_duplicate_hub_is_aborted(hass):
     MockConfigEntry(
         domain="hivemind",


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet (via Claude Code) — NOT human-reviewed. Verify before acting.

This fixes the config flow wiping every field when the hub rejects a submission, and cleans up the surrounding copy and install docs users hit while setting the integration up.

**Code fix (the one behavioral change).** `async_step_user` re-showed the form with a bare schema on error, so a typo in one field meant retyping host, access key, port, device type, name, and site id all over again. It now repopulates the schema with the previously entered values via `add_suggested_values_to_schema`, excluding the password on purpose so it isn't echoed back. `host` and `port` are also reordered next to each other in the schema since they describe one endpoint.

Fail-before: reverted only the `config_flow.py` change with a patch-revert (test kept in place). `test_error_preserves_entered_values_except_password` failed with `assert None == 'voice_assistant'` — the suggested values were empty. Reapplying the fix made that test and the other 4 config-flow tests pass.

**Copy fixes.** Error strings had backticks Home Assistant doesn't render in errors — removed those, kept them in the step `description` where they do render. `invalid_auth` now also mentions the port, since a wrong port currently surfaces as the same "invalid_auth" as a wrong password. Added `data_description` help text for host, port, site_id, and name. `site_id` no longer defaults to the literal string `"unknown"` (which read like a failed lookup); it's now an empty optional field, with the fallback still handled in `__init__.py` so `_build_bus`/identity behavior is unchanged. Device-type labels (`const.py`) now lead with a plain outcome ("Voice Assistant — full two-way voice (mic in, speaks back)") before the technical detail, and OCP is expanded once in the `legacy_audio` help text. `strings.json` and `translations/en.json` were kept byte-identical.

**Docs.** README.md and docs/setup.md both now state the prerelease install requirement (`hivemind_bus_client>=1.0.16a1`, matching the manifest's actual floor pin) before the "add the integration" step, since a stock Home Assistant install otherwise fails with `RequirementsNotFound` and that's the most common blocker reported by users. Both docs also now describe the host field consistently with what the client actually accepts — a bare hostname/IP or a `ws://`/`wss://` URL, with port as a separate field — verified against `hivemind_bus_client`'s `HiveMessageBusClient` construction, which strips any `ws://`/`wss://` prefix and derives the TLS flag from it.

Full tier-1 suite (`pytest tests -q --ignore=tests/e2e`): 22 passed. `ruff check custom_components tests`: all checks passed. `tests/e2e` was not run (needs a real hub).