### PR TITLE
fix: report refused connection as cannot_connect, not invalid_auth

### DIFF
--- a/custom_components/hivemind/config_flow.py
+++ b/custom_components/hivemind/config_flow.py
@@ -46,8 +46,8 @@ def _try_handshake(data: dict, identity_file: str) -> bool:
     try:
         try:
             _connect(bus, handshake_max_retries=1)
-        except (RuntimeError, ConnectionRefusedError):
-            # hub reachable but handshake never completed: bad key / password
+        except RuntimeError:
+            # hub answered but the bounded handshake never completed: bad key / password
             return False
         return bool(bus.handshake_event.is_set())
     finally:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -59,6 +59,35 @@ def test_wrong_password_bounds_handshake_and_closes(hass):
     assert close.called, "the validation client must be closed on failure"
 
 
+def test_refused_connection_is_not_reported_as_invalid_auth(hass):
+    """A refused TCP connection is a connectivity failure, not bad credentials.
+
+    ``ConnectionRefusedError`` means the hub was never reached (down, or a
+    wrong host/port) — it must propagate out of ``_try_handshake`` so
+    ``validate_connection`` maps it to ``cannot_connect``, not swallow it into
+    the ``invalid_auth`` path used for a completed-but-rejected handshake.
+    """
+    with patch.object(config_flow, "_connect", side_effect=ConnectionRefusedError()):
+        try:
+            config_flow._try_handshake(DATA, _identity_path(hass, DATA["access_key"]))
+            assert False, "expected ConnectionRefusedError to propagate"
+        except ConnectionRefusedError:
+            pass
+
+
+async def test_refused_connection_yields_cannot_connect_error_key(hass):
+    with patch.object(config_flow, "_connect", side_effect=ConnectionRefusedError()):
+        error = await config_flow.validate_connection(hass, DATA)
+    assert error == "cannot_connect"
+
+
+async def test_runtime_error_still_yields_invalid_auth(hass):
+    """Negative control: a bounded handshake timeout must still map to invalid_auth."""
+    with patch.object(config_flow, "_connect", side_effect=RuntimeError("timed out")):
+        error = await config_flow.validate_connection(hass, DATA)
+    assert error == "invalid_auth"
+
+
 async def test_validation_uses_persistent_identity_not_throwaway(hass):
     """Validation must build its client with the entry's persistent identity."""
     captured = {}


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

`_try_handshake` in `config_flow.py` caught `ConnectionRefusedError` alongside `RuntimeError` and mapped both outcomes to a plain `False` return, which `validate_connection` then turns into the `invalid_auth` error key shown to the user. A refused TCP connection means the hub was never reached at all — wrong host/port, or the hub process is down — which is a connectivity failure, not bad credentials. The inline comment even contradicted itself, describing the hub as "reachable" for an error that by definition means it was not.

The fix narrows the `except` clause to `RuntimeError` only. That case is the bounded handshake-timeout: on v3 Noise a wrong password makes the hub close the socket cleanly rather than raising a distinct error, so `RuntimeError` genuinely stays ambiguous between "wrong password" and "hub is slow," and mapping it to `invalid_auth` remains the correct best-effort guess. `ConnectionRefusedError` now propagates out of `_try_handshake`, through `async_add_executor_job`, and lands in `validate_connection`'s existing `except Exception` branch, which already returns `cannot_connect` — no new code path was needed there.

Added `tests/test_validation.py::test_refused_connection_is_not_reported_as_invalid_auth` and `test_refused_connection_yields_cannot_connect_error_key`, which mock `_connect` to raise `ConnectionRefusedError` and assert the exception propagates and that `validate_connection` returns `cannot_connect`. Added `test_runtime_error_still_yields_invalid_auth` as a negative control confirming the `RuntimeError` path is unchanged. Both new assertions were verified to fail against the unfixed code (patch-revert of the source only, keeping the tests) — they returned `invalid_auth` / raised nothing instead of propagating — and pass after restoring the fix. The full suite (25 tests, including these three) passes.