### PR TITLE
fix: query the ovos-media status topic and retire the legacy audio-service mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ The config flow asks for these fields when you add the integration:
 | `port` | `5678` | HiveMind WebSocket port; a separate field from `host`. |
 | `access_key` | n/a | HiveMind client access key. |
 | `password` | n/a | HiveMind client password. |
-| `legacy_audio` | `false` | Use the legacy Audio Service instead of OCP. |
 | `site_id` | empty | Optional OVOS site id; leave blank if you have one hub. |
 | `allow_self_signed` | `false` | Accept a self-signed TLS certificate. |
 
@@ -160,7 +159,8 @@ privileges and permission to use the following message types.
 - `mycroft.audio.speak.status`
 
 #### OCP (OpenVoiceOS Common Play)
-- `ovos.common_play.player.status`
+- `ovos.common_play.status`
+- `ovos.common_play.player.status` (legacy OCP audio service; queried until flag day)
 - `ovos.common_play.track_info`
 - `ovos.common_play.get_track_length`
 - `ovos.common_play.get_track_position`
@@ -176,18 +176,6 @@ privileges and permission to use the following message types.
 - `ovos.common_play.shuffle.unset`
 - `ovos.common_play.repeat.set`
 - `ovos.common_play.repeat.unset`
-- `ovos.common_play.repeat.one`
-
-#### Audio Service
-*(only if you enable it manually, for systems without the OCP Audio Plugin)*
-
-- `mycroft.audio.service.play`
-- `mycroft.audio.service.resume`
-- `mycroft.audio.service.pause`
-- `mycroft.audio.service.stop`
-- `mycroft.audio.service.prev`
-- `mycroft.audio.service.next`
-- `mycroft.audio.service.set_track_position`
 
 ### PHAL
 - `mycroft.phal.is_alive`

--- a/custom_components/hivemind/config_flow.py
+++ b/custom_components/hivemind/config_flow.py
@@ -20,7 +20,6 @@ HIVEMIND_SCHEMA = {
     vol.Required("port", default=5678): int,
     vol.Required("access_key"): str,
     vol.Required("password"): str,
-    vol.Required("legacy_audio", default=False): bool,
     vol.Optional("site_id"): str,
     vol.Required("allow_self_signed", default=False): bool,
 }

--- a/custom_components/hivemind/media_player.py
+++ b/custom_components/hivemind/media_player.py
@@ -72,10 +72,9 @@ SUPPORT_HIVEMIND = (
 
 
 class HiveMindMediaPlayer(HiveMindEntity, MediaPlayerEntity):
-    def __init__(self, bus: HiveMessageBusClient, site_id: str, name: str, legacy_audio: bool = False, **kwargs) -> None:
+    def __init__(self, bus: HiveMessageBusClient, site_id: str, name: str, **kwargs) -> None:
         """Initialize the service."""
         super().__init__(bus, site_id, name, **kwargs)
-        self.legacy_audioservice = legacy_audio
 
         self._state = MediaPlayerState.IDLE
         self._volume_level = 0.5
@@ -131,21 +130,32 @@ class HiveMindMediaPlayer(HiveMindEntity, MediaPlayerEntity):
 
     def handle_track_len(self, message: Message):
         _LOGGER.info(f"track info: {message.data}")
-        self._track_len = message.data.get("length", self._track_len)
+        # OCP/ovos-media report track length in milliseconds; HA's
+        # media_duration contract is seconds, so convert at this boundary.
+        if "length" in message.data:
+            self._track_len = message.data["length"] / 1000
         self.schedule_update_ha_state()
 
     def handle_track_pos(self, message: Message):
         _LOGGER.info(f"track info: {message.data}")
-        self._playback_pos = message.data.get("position", self._playback_pos)
+        # OCP/ovos-media report track position in milliseconds; HA's
+        # media_position contract is seconds, so convert at this boundary.
+        if "position" in message.data:
+            self._playback_pos = message.data["position"] / 1000
         if "length" in message.data:
-            self._track_len = message.data["length"]
+            self._track_len = message.data["length"] / 1000
         self.schedule_update_ha_state()
 
     def handle_status(self, message: Message):
         _LOGGER.info(f"OCP status: {message.data}")
-        player = message.data.get("state")
+        # bridges both stacks until flag day: legacy OCP answers
+        # 'ovos.common_play.player.status' with {state, repeat}, ovos-media
+        # answers 'ovos.common_play.status' with {player_state, loop_state} -
+        # both encode the same LoopState/PlayerState values, so a fallback
+        # read is enough, no separate decoding path needed.
+        player = message.data.get("player_state", message.data.get("state"))
         media = message.data.get("media_state")
-        repeat = message.data.get("repeat")
+        repeat = message.data.get("loop_state", message.data.get("repeat"))
         self._is_shuffle = message.data.get("shuffle", self._is_shuffle)
 
         if repeat == LoopState.REPEAT:
@@ -177,6 +187,7 @@ class HiveMindMediaPlayer(HiveMindEntity, MediaPlayerEntity):
         self._register("ovos.common_play.track.state", self.handle_ocp_track_state)
         self._register("ovos.common_play.player.state", self.handle_ocp_player_state)
         self._register("ovos.common_play.media.state", self.handle_ocp_media_state)
+        self._register("ovos.common_play.status.response", self.handle_status)
         self._register("ovos.common_play.player.status.response", self.handle_status)
 
     async def async_update(self):
@@ -185,6 +196,11 @@ class HiveMindMediaPlayer(HiveMindEntity, MediaPlayerEntity):
             self.send_to_ovos(Message("ovos.common_play.track_info"))
             self.send_to_ovos(Message("ovos.common_play.get_track_length"))
             self.send_to_ovos(Message("ovos.common_play.get_track_position"))
+            # queried on both topics: the legacy OCP audio service only
+            # answers 'ovos.common_play.player.status', ovos-media only
+            # answers 'ovos.common_play.status' - no stack serves both, so
+            # this is safe until legacy OCP is retired.
+            self.send_to_ovos(Message("ovos.common_play.status"))
             self.send_to_ovos(Message("ovos.common_play.player.status"))
 
     @property
@@ -350,34 +366,27 @@ class HiveMindMediaPlayer(HiveMindEntity, MediaPlayerEntity):
             m = "ovos.common_play.play"
 
         self._uri = media_id
-        if self.legacy_audioservice:
-            message = Message('mycroft.audio.service.play',
-                              {'tracks': [media_id]})
-        else:
-            entry = MediaEntry(
-                uri=media_id,
-                title="",
-                artist="",
-                length=0,
-                match_confidence=100,
-                skill_id="homeassistant.hivemind",
-                skill_icon="https://raw.githubusercontent.com/home-assistant/brands/refs/heads/master/core_integrations/music_assistant/icon.png",
-                image="",
-                status=TrackState.QUEUED_AUDIO,
-                media_type=mapping.get(media_type, OCPMediaType.MUSIC),
-                playback=PlaybackType.AUDIO,
-            )
-            message = Message(m, {"media": entry.as_dict})
+        entry = MediaEntry(
+            uri=media_id,
+            title="",
+            artist="",
+            length=0,
+            match_confidence=100,
+            skill_id="homeassistant.hivemind",
+            skill_icon="https://raw.githubusercontent.com/home-assistant/brands/refs/heads/master/core_integrations/music_assistant/icon.png",
+            image="",
+            status=TrackState.QUEUED_AUDIO,
+            media_type=mapping.get(media_type, OCPMediaType.MUSIC),
+            playback=PlaybackType.AUDIO,
+        )
+        message = Message(m, {"media": entry.as_dict})
         self.send_to_ovos(message)
 
 
     async def async_media_play(self):
         """Send play command."""
         self._state = MediaPlayerState.PLAYING
-        if self.legacy_audioservice:
-            message = Message('mycroft.audio.service.resume')
-        else:
-            message = Message('ovos.common_play.resume')
+        message = Message('ovos.common_play.resume')
         _LOGGER.info("play")
         self.send_to_ovos(message)
         self.async_write_ha_state()
@@ -385,10 +394,7 @@ class HiveMindMediaPlayer(HiveMindEntity, MediaPlayerEntity):
     async def async_media_pause(self):
         self._state = MediaPlayerState.PAUSED
         _LOGGER.info("pause")
-        if self.legacy_audioservice:
-            message = Message('mycroft.audio.service.pause')
-        else:
-            message = Message('ovos.common_play.pause')
+        message = Message('ovos.common_play.pause')
 
         self.send_to_ovos(message)
         self.async_write_ha_state()
@@ -396,10 +402,7 @@ class HiveMindMediaPlayer(HiveMindEntity, MediaPlayerEntity):
     async def async_media_stop(self):
         self._state = MediaPlayerState.IDLE
         _LOGGER.info("stop")
-        if self.legacy_audioservice:
-            message = Message('mycroft.audio.service.stop')
-        else:
-            message = Message('ovos.common_play.stop')
+        message = Message('ovos.common_play.stop')
 
         self.send_to_ovos(message)
         self.async_write_ha_state()
@@ -448,10 +451,7 @@ class HiveMindMediaPlayer(HiveMindEntity, MediaPlayerEntity):
 
     async def async_media_previous_track(self) -> None:
         """Send previous track command."""
-        if self.legacy_audioservice:
-            message = Message('mycroft.audio.service.prev')
-        else:
-            message = Message('ovos.common_play.previous')
+        message = Message('ovos.common_play.previous')
         _LOGGER.info("previous track")
         self.send_to_ovos(message)
         self.async_write_ha_state()
@@ -460,21 +460,16 @@ class HiveMindMediaPlayer(HiveMindEntity, MediaPlayerEntity):
         """Send next track command."""
         _LOGGER.info("next track")
 
-        if self.legacy_audioservice:
-            message = Message('mycroft.audio.service.next')
-        else:
-            message = Message('ovos.common_play.next')
+        message = Message('ovos.common_play.next')
         self.send_to_ovos(message)
         self.async_write_ha_state()
 
     async def async_media_seek(self, position: float) -> None:
         """Send seek command."""
-        if self.legacy_audioservice:
-            message = Message('mycroft.audio.service.set_track_position',
-                              {"position": int(position * 1000)})
-        else:
-            message = Message('ovos.common_play.set_track_position',
-                              {"position": position})
+        # HA passes 'position' in seconds; OCP/ovos-media's
+        # set_track_position takes milliseconds.
+        message = Message('ovos.common_play.set_track_position',
+                          {"position": int(position * 1000)})
         self.send_to_ovos(message)
         _LOGGER.info(f"seek: {position}")
         self._playback_pos = position
@@ -503,10 +498,13 @@ class HiveMindMediaPlayer(HiveMindEntity, MediaPlayerEntity):
         """Set repeat mode."""
         if repeat == RepeatMode.OFF: # no repeat
             message = Message('ovos.common_play.repeat.unset')
-        elif repeat == RepeatMode.ALL: # repeat playlist in loop
+        else:
+            # ovos-media exposes no repeat-track verb - 'repeat.set' only
+            # reaches LoopState.REPEAT (playlist loop), never REPEAT_TRACK
+            # (see handle_set_repeat in ovos_media/player/__init__.py) -
+            # so RepeatMode.ONE falls back to playlist-loop until ovos-media
+            # grows a repeat-track bus verb.
             message = Message('ovos.common_play.repeat.set')
-        else: # repeat same track in loop
-            message = Message('ovos.common_play.repeat.one')
 
         _LOGGER.info(f"set repeat: {repeat}")
         self._repeat = repeat
@@ -522,14 +520,12 @@ async def async_setup_entry(
     # Get config values
     name = entry.data.get("name", "unnamed device")
     site_id = entry.data.get("site_id", "unknown")
-    legacy_audio = entry.data.get("legacy_audio", False)
 
     # Create the connection button entity
     connection_button = HiveMindMediaPlayer(
         bus=entry.hm_bus,
         name=name,
         site_id=site_id,
-        legacy_audio=legacy_audio
     )
 
     # Add it to Home Assistant

--- a/custom_components/hivemind/strings.json
+++ b/custom_components/hivemind/strings.json
@@ -11,7 +11,6 @@
           "port": "Port",
           "access_key": "Access key",
           "password": "Password",
-          "legacy_audio": "Use the legacy audio service instead of OCP",
           "site_id": "Site ID",
           "allow_self_signed": "Allow self-signed certificates"
         },
@@ -19,8 +18,7 @@
           "host": "Hub address — hostname or IP, e.g. 192.168.1.10; ws:// or wss:// optional",
           "port": "Must match your hub's listener; default 5678",
           "site_id": "Optional grouping label; leave as-is if you have one hub",
-          "name": "Friendly name shown in Home Assistant, e.g. 'Living Room HiveMind'",
-          "legacy_audio": "OCP is the OVOS media-playback system; enable this to use the older audio service instead"
+          "name": "Friendly name shown in Home Assistant, e.g. 'Living Room HiveMind'"
         }
       }
     },

--- a/custom_components/hivemind/translations/en.json
+++ b/custom_components/hivemind/translations/en.json
@@ -11,7 +11,6 @@
           "port": "Port",
           "access_key": "Access key",
           "password": "Password",
-          "legacy_audio": "Use the legacy audio service instead of OCP",
           "site_id": "Site ID",
           "allow_self_signed": "Allow self-signed certificates"
         },
@@ -19,8 +18,7 @@
           "host": "Hub address — hostname or IP, e.g. 192.168.1.10; ws:// or wss:// optional",
           "port": "Must match your hub's listener; default 5678",
           "site_id": "Optional grouping label; leave as-is if you have one hub",
-          "name": "Friendly name shown in Home Assistant, e.g. 'Living Room HiveMind'",
-          "legacy_audio": "OCP is the OVOS media-playback system; enable this to use the older audio service instead"
+          "name": "Friendly name shown in Home Assistant, e.g. 'Living Room HiveMind'"
         }
       }
     },

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,6 @@ the integration. There is no YAML.
 | `access_key` | n/a | HiveMind client access key. |
 | `password` | n/a | HiveMind client password. |
 | `port` | `5678` | HiveMind WebSocket port. |
-| `legacy_audio` | `false` | Use the legacy Audio Service instead of OCP for playback. |
 | `site_id` | `unknown` | OVOS site id. |
 | `allow_self_signed` | `false` | Accept a self-signed TLS certificate from the hub. |
 

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -29,8 +29,7 @@ that exposes each entity.
 | Notify | notify | Send text to OVOS to speak (TTS). |
 
 The media player maps Home Assistant `MediaType` values to OVOS OCP media
-types (music, video, movie, episode, TV channel, game, and others). With
-`legacy_audio` enabled, it drives the legacy Audio Service instead of OCP.
+types (music, video, movie, episode, TV channel, game, and others).
 
 ## `voice_assistant` only
 

--- a/tests/e2e/test_ha_integration_e2e.py
+++ b/tests/e2e/test_ha_integration_e2e.py
@@ -49,7 +49,6 @@ def _entry_data(url: str) -> dict:
         "access_key": SAT_KEY,
         "password": SAT_PASSWORD,
         "port": parsed.port,
-        "legacy_audio": False,
         "site_id": "e2e",
         "allow_self_signed": False,
     }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -17,7 +17,6 @@ USER_INPUT = {
     "access_key": "key",
     "password": "pw",
     "port": 5678,
-    "legacy_audio": False,
     "site_id": "test",
     "allow_self_signed": False,
 }

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -17,7 +17,6 @@ DATA = {
     "access_key": "key",
     "password": "pw",
     "port": 5678,
-    "legacy_audio": False,
     "site_id": "test",
     "allow_self_signed": False,
 }
@@ -73,13 +72,114 @@ async def test_malformed_ocp_status_does_not_raise(hass):
     await _setup(hass, fake)
     # empty payloads must not blow up any handler
     for event in (
-        "ovos.common_play.player.status.response",
+        "ovos.common_play.status.response",
         "ovos.common_play.media.state",
         "ovos.common_play.get_track_length.response",
         "mycroft.volume.get.response",
     ):
         fake.inject(event, {})
     await hass.async_block_till_done()
+
+
+async def test_status_query_uses_both_stacks_topics(hass):
+    """Regression: legacy OCP answers only 'ovos.common_play.player.status',
+    ovos-media answers only 'ovos.common_play.status' - no stack serves
+    both, so async_update queries both until legacy OCP is retired."""
+    fake = FakeHiveBus()
+    await _setup(hass, fake)
+    mp = _one(hass, "media_player")
+    component = hass.data["entity_components"]["media_player"]
+    entity = next(e for e in component.entities if e.entity_id == mp)
+    await entity.async_update()
+
+    emitted_types = [m.payload.msg_type for m in fake.emitted]
+    assert "ovos.common_play.status" in emitted_types
+    assert "ovos.common_play.player.status" in emitted_types
+
+
+async def test_ocp_status_response_updates_player_state(hass):
+    """ovos-media's handle_status answers with PlayerSnapshot.as_status_dict,
+    which uses 'player_state'/'loop_state' keys, not 'state'/'repeat'."""
+    fake = FakeHiveBus()
+    await _setup(hass, fake)
+    mp = _one(hass, "media_player")
+
+    from ovos_utils.ocp import PlayerState
+
+    fake.inject(
+        "ovos.common_play.status.response",
+        {
+            "player_state": PlayerState.PLAYING,
+            "media_state": None,
+            "loop_state": None,
+            "shuffle": False,
+        },
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(mp).state == "playing"
+
+
+async def test_legacy_ocp_status_response_updates_player_state(hass):
+    """Legacy OCP's handle_state_request answers with 'state'/'repeat'
+    keys (see ovos_plugin_common_play/ocp/player.py handle_state_request) -
+    handle_status must still parse this shape until legacy OCP is retired."""
+    fake = FakeHiveBus()
+    await _setup(hass, fake)
+    mp = _one(hass, "media_player")
+
+    from ovos_utils.ocp import LoopState, PlayerState
+
+    fake.inject(
+        "ovos.common_play.player.status.response",
+        {
+            "state": PlayerState.PLAYING,
+            "media_state": None,
+            "repeat": LoopState.REPEAT.value,
+            "shuffle": False,
+        },
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(mp)
+    assert state.state == "playing"
+    assert state.attributes.get("repeat") == "all"
+
+
+async def test_seek_sends_milliseconds(hass):
+    """Regression: HA's async_media_seek gets a position in seconds, but
+    OCP/ovos-media's set_track_position expects milliseconds."""
+    fake = FakeHiveBus()
+    await _setup(hass, fake)
+    mp = _one(hass, "media_player")
+    component = hass.data["entity_components"]["media_player"]
+    entity = next(e for e in component.entities if e.entity_id == mp)
+
+    await entity.async_media_seek(12.5)
+
+    seek_msgs = [
+        m.payload for m in fake.emitted
+        if m.payload.msg_type == "ovos.common_play.set_track_position"
+    ]
+    assert seek_msgs
+    assert seek_msgs[-1].data["position"] == 12500
+
+
+async def test_track_position_response_is_converted_to_seconds(hass):
+    """Regression: ovos-media answers get_track_position/get_track_length
+    in milliseconds, but HA's media_position/media_duration contract is
+    seconds."""
+    fake = FakeHiveBus()
+    await _setup(hass, fake)
+    mp = _one(hass, "media_player")
+
+    fake.inject(
+        "ovos.common_play.get_track_position.response",
+        {"position": 45000, "length": 180000},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(mp)
+    assert state.attributes.get("media_position") == 45
+    assert state.attributes.get("media_duration") == 180
 
 
 async def test_listener_sensor_has_no_state_class_and_updates(hass):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -16,7 +16,6 @@ BASE_DATA = {
     "access_key": "key",
     "password": "pw",
     "port": 5678,
-    "legacy_audio": False,
     "site_id": "test",
     "allow_self_signed": False,
 }
@@ -54,6 +53,22 @@ async def test_platforms_per_device_type(hass, device_type, expected, absent):
         assert hass.states.async_entity_ids(platform), f"missing {platform}"
     for platform in absent:
         assert not hass.states.async_entity_ids(platform), f"unexpected {platform}"
+
+
+async def test_stale_legacy_audio_key_is_ignored(hass):
+    """Regression: a config entry saved before legacy_audio was retired must
+    still set up cleanly, the stored key is simply never read."""
+    fake = FakeHiveBus()
+    entry = MockConfigEntry(
+        domain="hivemind",
+        data={**BASE_DATA, "device_type": "media_player", "legacy_audio": True},
+        entry_id="e-stale-legacy-audio",
+    )
+    entry.add_to_hass(hass)
+    with patch.object(hivemind, "_build_bus", return_value=fake):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    assert hass.states.async_entity_ids("media_player")
 
 
 async def test_unload_closes_bus_and_clears_data(hass):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -16,7 +16,6 @@ ENTRY_DATA = {
     "access_key": "key",
     "password": "pw",
     "port": 5678,
-    "legacy_audio": False,
     "site_id": "test",
     "allow_self_signed": False,
 }

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -25,7 +25,6 @@ DATA = {
     "access_key": "0123456789abcdef",
     "password": "wrong-password",
     "port": 5678,
-    "legacy_audio": False,
     "site_id": "test",
     "allow_self_signed": False,
 }


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

HA users today may be pointed at either the legacy ovos-audio+OCP stack or the ovos-media daemon replacing it. The two answer status on disjoint topics with disjoint payload shapes: legacy OCP serves only `ovos.common_play.player.status` -> `{state, media_state, shuffle, repeat}`, ovos-media serves only `ovos.common_play.status` -> `{player_state, media_state, shuffle, loop_state}`. Neither stack answers the other's topic, so `async_update` now queries both, and one `handle_status` reads whichever key set the response actually has (`player_state`/`state`, `loop_state`/`repeat` — both encode the same `PlayerState`/`LoopState` values). This is a bridging window, not a permanent dual-emit: once legacy OCP is retired org-wide, the legacy topic query and fallback keys go away.

The `legacy_audio` config-flow option and its `mycroft.audio.service.*` routing branches are removed, including the `strings.json`/`translations/en.json` UI copy (hassfest does not catch stale strings for custom integrations, so this was grep-verified separately: zero `legacy_audio` hits outside the one test asserting a stale config entry doesn't crash). ovos-media does not serve those verbs at all, so the mode was already dead against the new stack. A config entry saved before this change may still carry a stored `legacy_audio` key; it is simply never read now, so setup does not raise on it.

Fixing this surfaced a real unit bug: HA's `media_position`/`media_duration`/`async_media_seek` contract is seconds, but both OCP stacks report and expect track position/length in milliseconds. The legacy-audio branch this PR deletes was the only place doing a ms conversion, and only for the outbound seek — the inbound `get_track_length`/`get_track_position` responses were stored and exposed to HA unconverted. Both directions are now converted at the boundary: inbound ms -> seconds on ingestion, outbound seconds -> ms on `async_media_seek`.

`RepeatMode.ONE` has no reachable ovos-media bus verb. ovos-media's `handle_set_repeat` unconditionally sets `LoopState.REPEAT` (playlist loop); the only path to `LoopState.REPEAT_TRACK` is a stateful toggle-cycle, not addressable by a single `set` call. `RepeatMode.ONE` now falls back to `ovos.common_play.repeat.set` (playlist loop) with a comment explaining why, and `ovos.common_play.repeat.one` — which ovos-media never implemented — is dropped from the README's OCP topic allowlist. Repeat-track needs a real bus verb from ovos-media before this can be fixed properly; that's a follow-up on the daemon, not this integration.

Test plan: reverted only the source changes (`media_player.py`, `config_flow.py`, `strings.json`, `translations/en.json`) via patch-revert with the test changes kept in place. `test_status_query_uses_both_stacks_topics`, `test_legacy_ocp_status_response_updates_player_state`, `test_seek_sends_milliseconds`, and `test_track_position_response_is_converted_to_seconds` all failed; restoring the fix made them pass. `pytest tests -q --ignore=tests/e2e` reports 31 passed (27 on the original tree, 28 after the first fix round, 31 after this round). `tests/e2e` needs a live hivemind-core hub per CI and was not run; the changed files were compile-checked instead.